### PR TITLE
[#8] MVI 리팩터링 : 공통코드 제거 및 제네릭 제한

### DIFF
--- a/core/common-android/src/main/java/team/noweekend/core/common/android/base/MVIViewModel.kt
+++ b/core/common-android/src/main/java/team/noweekend/core/common/android/base/MVIViewModel.kt
@@ -40,9 +40,9 @@ abstract class MVIViewModel<I : Intent, SE : SideEffect, S : UiState>(
     protected val currentState: S
         get() = _uiState.value
 
-    private val _sideEffect: Channel<SideEffect> =
+    private val _sideEffect: Channel<SE> =
         Channel(onBufferOverflow = BufferOverflow.DROP_OLDEST)
-    val sideEffect: Flow<SideEffect> = _sideEffect.receiveAsFlow()
+    val sideEffect: Flow<SE> = _sideEffect.receiveAsFlow()
 
     protected val coroutineExceptionHandler: CoroutineExceptionHandler =
         CoroutineExceptionHandler { _, throwable ->
@@ -62,7 +62,7 @@ abstract class MVIViewModel<I : Intent, SE : SideEffect, S : UiState>(
      *
      * @param intent 전달할 Intent 객체
      */
-    fun intent(intent: Intent): Job = execute {
+    fun intent(intent: I): Job = execute {
         handleIntent(intent)
     }
 
@@ -78,11 +78,7 @@ abstract class MVIViewModel<I : Intent, SE : SideEffect, S : UiState>(
      *
      * @param intent 수신한 Intent 객체
      */
-    protected abstract suspend fun handleIntent(intent: Intent)
-
-    protected open fun navigateBack(): Job = execute {
-        postSideEffect(SideEffect.NavigateToHistoryBack)
-    }
+    protected abstract suspend fun handleIntent(intent: I)
 
     /**
      * 앱 내 상태 변경이 아닌 추적, 탐색 등과 같은 작업을 사이드 이펙트를 통해 처리합니다.
@@ -91,7 +87,7 @@ abstract class MVIViewModel<I : Intent, SE : SideEffect, S : UiState>(
      *
      * @param sideEffect 전달할 SideEffect 객체
      */
-    protected suspend fun postSideEffect(sideEffect: SideEffect) {
+    protected suspend fun postSideEffect(sideEffect: SE) {
         _sideEffect.send(sideEffect)
     }
 

--- a/core/common-android/src/main/java/team/noweekend/core/common/android/mvi/Intent.kt
+++ b/core/common-android/src/main/java/team/noweekend/core/common/android/mvi/Intent.kt
@@ -3,6 +3,4 @@ package team.noweekend.core.common.android.mvi
 /**
  * 기본 Intent 추상화 정의
  */
-interface Intent {
-    data object ClickBackButton : Intent
-}
+interface Intent

--- a/core/common-android/src/main/java/team/noweekend/core/common/android/mvi/SideEffect.kt
+++ b/core/common-android/src/main/java/team/noweekend/core/common/android/mvi/SideEffect.kt
@@ -3,6 +3,4 @@ package team.noweekend.core.common.android.mvi
 /**
  * 기본 SideEffect 추상화 정의
  */
-interface SideEffect {
-    data object NavigateToHistoryBack : SideEffect
-}
+interface SideEffect

--- a/feature/sample/src/main/java/team/noweekend/feature/sample/SampleNavHost.kt
+++ b/feature/sample/src/main/java/team/noweekend/feature/sample/SampleNavHost.kt
@@ -21,8 +21,10 @@ internal fun SampleNavHost(
         startDestination = Sample.Home
     ) {
         sampleScreen(
-            navigateToMemberDetail = navController::navigateToSampleDetail
+            navigateToMemberDetail = navController::navigateToSampleDetail,
         )
-        sampleDetailScreen()
+        sampleDetailScreen(
+            navigateToHistoryBack = navController::navigateUp,
+        )
     }
 }

--- a/feature/sample/src/main/java/team/noweekend/feature/sample/detail/mvi/SampleDetailIntent.kt
+++ b/feature/sample/src/main/java/team/noweekend/feature/sample/detail/mvi/SampleDetailIntent.kt
@@ -2,4 +2,6 @@ package team.noweekend.feature.sample.detail.mvi
 
 import team.noweekend.core.common.android.mvi.Intent
 
-sealed interface SampleDetailIntent : Intent
+sealed interface SampleDetailIntent : Intent {
+    data object ClickBackButton : SampleDetailIntent
+}

--- a/feature/sample/src/main/java/team/noweekend/feature/sample/detail/mvi/SampleDetailSideEffect.kt
+++ b/feature/sample/src/main/java/team/noweekend/feature/sample/detail/mvi/SampleDetailSideEffect.kt
@@ -2,4 +2,6 @@ package team.noweekend.feature.sample.detail.mvi
 
 import team.noweekend.core.common.android.mvi.SideEffect
 
-sealed interface SampleDetailSideEffect : SideEffect
+sealed interface SampleDetailSideEffect : SideEffect {
+    data object NavigateToHistoryBack : SampleDetailSideEffect
+}

--- a/feature/sample/src/main/java/team/noweekend/feature/sample/detail/mvi/SampleDetailViewModel.kt
+++ b/feature/sample/src/main/java/team/noweekend/feature/sample/detail/mvi/SampleDetailViewModel.kt
@@ -4,8 +4,8 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.toRoute
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.Job
 import team.noweekend.core.common.android.base.MVIViewModel
-import team.noweekend.core.common.android.mvi.Intent
 import team.noweekend.core.navigator.model.Sample
 import javax.inject.Inject
 
@@ -25,9 +25,13 @@ class SampleDetailViewModel @Inject constructor(
 
     override fun handleClientException(throwable: Throwable) {}
 
-    override suspend fun handleIntent(intent: Intent) {
+    override suspend fun handleIntent(intent: SampleDetailIntent) {
         when (intent) {
-            is Intent.ClickBackButton -> navigateBack()
+            is SampleDetailIntent.ClickBackButton -> navigateBack()
         }
+    }
+
+    private fun navigateBack(): Job = execute {
+        postSideEffect(SampleDetailSideEffect.NavigateToHistoryBack)
     }
 }

--- a/feature/sample/src/main/java/team/noweekend/feature/sample/detail/navigation/SampleDetailNavigation.kt
+++ b/feature/sample/src/main/java/team/noweekend/feature/sample/detail/navigation/SampleDetailNavigation.kt
@@ -10,8 +10,12 @@ internal fun NavHostController.navigateToSampleDetail(members: List<String>) {
     navigate(Sample.Detail(members))
 }
 
-internal fun NavGraphBuilder.sampleDetailScreen() {
+internal fun NavGraphBuilder.sampleDetailScreen(
+    navigateToHistoryBack: () -> Unit,
+) {
     composable<Sample.Detail> {
-        SampleDetailRoute()
+        SampleDetailRoute(
+            navigateToHistoryBack = navigateToHistoryBack,
+        )
     }
 }

--- a/feature/sample/src/main/java/team/noweekend/feature/sample/detail/screen/SampleDetailRoute.kt
+++ b/feature/sample/src/main/java/team/noweekend/feature/sample/detail/screen/SampleDetailRoute.kt
@@ -1,5 +1,6 @@
 package team.noweekend.feature.sample.detail.screen
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -7,19 +8,24 @@ import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.flow.collectLatest
+import team.noweekend.feature.sample.detail.mvi.SampleDetailIntent
+import team.noweekend.feature.sample.detail.mvi.SampleDetailSideEffect
 import team.noweekend.feature.sample.detail.mvi.SampleDetailViewModel
 
 @Composable
 internal fun SampleDetailRoute(
     modifier: Modifier = Modifier,
     viewModel: SampleDetailViewModel = hiltViewModel(),
+    navigateToHistoryBack: () -> Unit,
 ) {
+    BackHandler { viewModel.intent(SampleDetailIntent.ClickBackButton) }
+
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     LaunchedEffect(key1 = viewModel) {
         viewModel.sideEffect.collectLatest { sideEffect ->
             when (sideEffect) {
-                else -> {}
+                is SampleDetailSideEffect.NavigateToHistoryBack -> navigateToHistoryBack()
             }
         }
     }
@@ -27,5 +33,6 @@ internal fun SampleDetailRoute(
     SampleDetailScreen(
         modifier = modifier,
         uiState = uiState,
+        onBackClick = { viewModel.intent(SampleDetailIntent.ClickBackButton) }
     )
 }

--- a/feature/sample/src/main/java/team/noweekend/feature/sample/detail/screen/SampleDetailScreen.kt
+++ b/feature/sample/src/main/java/team/noweekend/feature/sample/detail/screen/SampleDetailScreen.kt
@@ -1,7 +1,7 @@
 package team.noweekend.feature.sample.detail.screen
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -9,29 +9,33 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import team.noweekend.feature.sample.detail.mvi.SampleDetailUiState
-import team.noweekend.feature.sample.home.mvi.SampleUiState
-import team.noweekend.feature.sample.home.screen.SampleScreen
 
 @Composable
 fun SampleDetailScreen(
     modifier: Modifier = Modifier,
     uiState: SampleDetailUiState,
+    onBackClick: () -> Unit,
 ) {
-    Column(
+    Box(
         modifier = modifier.fillMaxSize(),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.SpaceEvenly
+        contentAlignment = Alignment.Center
     ) {
+        Text(
+            modifier = Modifier
+                .align(Alignment.TopStart)
+                .clickable(onClick = onBackClick),
+            text = "여기누르면 뒤로가요~",
+        )
         Text(uiState.members.toString())
     }
 }
 
 @Preview
 @Composable
-private fun SampleScreenPreview() {
-    SampleScreen(
+private fun SampleDetailScreenPreview() {
+    SampleDetailScreen(
         modifier = Modifier.fillMaxSize(),
-        uiState = SampleUiState.INITIAL_STATE,
-        onDetailButtonClick = {},
+        uiState = SampleDetailUiState.INITIAL_STATE,
+        onBackClick = {},
     )
 }

--- a/feature/sample/src/main/java/team/noweekend/feature/sample/home/mvi/SampleIntent.kt
+++ b/feature/sample/src/main/java/team/noweekend/feature/sample/home/mvi/SampleIntent.kt
@@ -3,5 +3,6 @@ package team.noweekend.feature.sample.home.mvi
 import team.noweekend.core.common.android.mvi.Intent
 
 sealed interface SampleIntent : Intent {
+    data object ClickBackButton : SampleIntent
     data object ClickMemberDetailButton : SampleIntent
 }

--- a/feature/sample/src/main/java/team/noweekend/feature/sample/home/mvi/SampleSideEffect.kt
+++ b/feature/sample/src/main/java/team/noweekend/feature/sample/home/mvi/SampleSideEffect.kt
@@ -3,6 +3,7 @@ package team.noweekend.feature.sample.home.mvi
 import team.noweekend.core.common.android.mvi.SideEffect
 
 sealed interface SampleSideEffect : SideEffect {
+    data object NavigateToHistoryBack : SampleSideEffect
     data class NavigateToMemberDetail(
         val members: List<String>,
     ) : SampleSideEffect

--- a/feature/sample/src/main/java/team/noweekend/feature/sample/home/mvi/SampleViewModel.kt
+++ b/feature/sample/src/main/java/team/noweekend/feature/sample/home/mvi/SampleViewModel.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.SavedStateHandle
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import team.noweekend.core.common.android.base.MVIViewModel
-import team.noweekend.core.common.android.mvi.Intent
 import javax.inject.Inject
 
 @HiltViewModel
@@ -20,11 +19,15 @@ class SampleViewModel @Inject constructor(
 
     override fun handleClientException(throwable: Throwable) {}
 
-    override suspend fun handleIntent(intent: Intent) {
+    override suspend fun handleIntent(intent: SampleIntent) {
         when (intent) {
-            is Intent.ClickBackButton -> navigateBack()
+            is SampleIntent.ClickBackButton -> navigateBack()
             is SampleIntent.ClickMemberDetailButton -> navigateToMemberDetail()
         }
+    }
+
+    private fun navigateBack(): Job = execute {
+        postSideEffect(SampleSideEffect.NavigateToHistoryBack)
     }
 
     private fun navigateToMemberDetail(): Job = execute {


### PR DESCRIPTION
### What is this PR (Required)
- **Issue Number** : #8 

### Changes (Required)
- MVIVIewModel의 제네릭 한정 및 navigateBack 공통코드 제거
- Intent, SideEffect 인터페이스 미사용 객체 제거
- navigateBack 임시 로직 추가

### Review Point (Required)
- 기존 #8 에서 꺠꺠오톡으로 논의한 공통코드 제거에 대한 pr 입니당
- 앞으로 공통코드에 대한 논의는 작업 전에 충분히 논의한 후에 넣으면 좋을 것 같습니다~ 미리 넣어놔서 ㅈㅅㅈㅅ ^^!!
  - extension, Util 함수 분리에 대한 부분도 포함!

### 관련 Reference 자료
- none