### PR TITLE
[#64] 연차 추천 정보 선택 스크린 구성

### DIFF
--- a/core/resource/src/main/kotlin/team/noweekend/core/resource/NWKStringResource.kt
+++ b/core/resource/src/main/kotlin/team/noweekend/core/resource/NWKStringResource.kt
@@ -37,6 +37,8 @@ object NWKStringResource {
 
     val CreateVacationDateHeader: Int = R.string.create_vacation_date_header
     val CreateVacationDateRemainedDaysDescription: Int = R.string.create_vacation_date_remained_days_description
+    val CreateVacationInformationHeader: Int = R.string.create_vacation_information_header
+    val CreateVacationInformationDescription: Int = R.string.create_vacation_information_description
 
     val Monday: Int = R.string.monday
     val Tuesday: Int = R.string.tuesday

--- a/core/resource/src/main/res/values/strings.xml
+++ b/core/resource/src/main/res/values/strings.xml
@@ -35,6 +35,8 @@
 
     <string name="create_vacation_date_header">휴가로 사용할\n연차 일수를 입력해주세요.</string>
     <string name="create_vacation_date_remained_days_description">"남은 연차 %1$s일"</string>
+    <string name="create_vacation_information_header">딱 맞는 연차를 찾기 위해\n정보를 참고할게요</string>
+    <string name="create_vacation_information_description">나를 표현하는 단어 선택</string>
 
     <string name="monday">월</string>
     <string name="tuesday">화</string>

--- a/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/CreateVacationNavHost.kt
+++ b/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/CreateVacationNavHost.kt
@@ -9,6 +9,7 @@ import team.noweekend.core.navigator.model.CreateVacation
 import team.noweekend.feature.create.vacation.date.navigation.vacationDateGraph
 import team.noweekend.feature.create.vacation.information.navigation.informationGraph
 import team.noweekend.feature.create.vacation.information.navigation.navigateToInformation
+import team.noweekend.feature.create.vacation.recommend.navigation.navigateToVacationRecommendation
 import team.noweekend.feature.create.vacation.recommend.navigation.recommendGraph
 
 @Composable
@@ -27,7 +28,10 @@ internal fun CreateVacationNavHost(
             navigateToHistoryBack = { navController.popBackStack(finish) },
             navigateToInformation = navController::navigateToInformation,
         )
-        informationGraph()
+        informationGraph(
+            navigateToHistoryBack = { navController.popBackStack(finish) },
+            navigateToVacationRecommendation = navController::navigateToVacationRecommendation
+        )
         recommendGraph()
     }
 }

--- a/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/component/button/InformationSelectRadioButton.kt
+++ b/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/component/button/InformationSelectRadioButton.kt
@@ -37,7 +37,7 @@ import team.noweekend.feature.create.vacation.information.model.InformationRadio
 
 @Composable
 internal fun InformationSelectRadioGroupContent(
-    information: ImmutableMap<Int, ImmutableList<InformationRadioGroupUiModel>>,
+    informationData: ImmutableMap<Int, ImmutableList<InformationRadioGroupUiModel>>,
     selectInformation: (Int, InformationRadioGroupUiModel) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -45,11 +45,11 @@ internal fun InformationSelectRadioGroupContent(
         modifier = modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(NWKTheme.spacing.space300),
     ) {
-        information.forEach { (row, informationList) ->
-            key(informationList) {
+        informationData.forEach { (rowIndex, informationRow) ->
+            key(informationRow) {
                 InformationSelectRadioGroup(
-                    information = informationList,
-                    selectInformation = { selectInformation(row, it) },
+                    informationRow = informationRow,
+                    selectInformation = { selectInformation(rowIndex, it) },
                 )
             }
         }
@@ -58,11 +58,11 @@ internal fun InformationSelectRadioGroupContent(
 
 @Composable
 internal fun InformationSelectRadioGroup(
-    information: ImmutableList<InformationRadioGroupUiModel>,
+    informationRow: ImmutableList<InformationRadioGroupUiModel>,
     selectInformation: (InformationRadioGroupUiModel) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val (first, last) = information
+    val (first, last) = informationRow
 
     Row(
         modifier = modifier.fillMaxWidth(),
@@ -134,12 +134,12 @@ internal fun InformationSelectRadioButton(
 @Preview
 @Composable
 private fun InformationSelectRadioGroupPreview(
-    @PreviewParameter(PreviewInformationSelectRadioGroupProvider::class) informations: ImmutableList<InformationRadioGroupUiModel>,
+    @PreviewParameter(PreviewInformationSelectRadioGroupProvider::class) informationRow: ImmutableList<InformationRadioGroupUiModel>,
 ) {
     NWKTheme {
         Box(modifier = Modifier.background(NWKTheme.color.Neutral.white)) {
             InformationSelectRadioGroup(
-                information = informations,
+                informationRow = informationRow,
                 selectInformation = {},
             )
         }

--- a/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/component/button/InformationSelectRadioButton.kt
+++ b/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/component/button/InformationSelectRadioButton.kt
@@ -1,28 +1,94 @@
 package team.noweekend.feature.create.vacation.information.component.button
 
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
-import androidx.compose.ui.unit.dp
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.ImmutableMap
 import team.noweekend.core.design.system.foundation.theme.NWKTheme
 import team.noweekend.feature.create.vacation.information.component.button.defaults.InformationSelectRadioButtonColors
 import team.noweekend.feature.create.vacation.information.component.button.defaults.InformationSelectRadioButtonDefaults
 import team.noweekend.feature.create.vacation.information.component.button.preview.PreviewInformationSelectRadioButtonProvider
-import team.noweekend.feature.create.vacation.information.model.SelectedInformationUiModel
+import team.noweekend.feature.create.vacation.information.component.button.preview.PreviewInformationSelectRadioGroupProvider
+import team.noweekend.feature.create.vacation.information.model.InformationRadioGroupUiModel
+
+@Composable
+internal fun InformationSelectRadioGroupContent(
+    information: ImmutableMap<Int, ImmutableList<InformationRadioGroupUiModel>>,
+    selectInformation: (Int, InformationRadioGroupUiModel) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(NWKTheme.spacing.space300),
+    ) {
+        information.forEach { (row, informationList) ->
+            InformationSelectRadioGroup(
+                information = informationList,
+                selectInformation = { selectInformation(row, it) },
+            )
+        }
+    }
+}
+
+@Composable
+internal fun InformationSelectRadioGroup(
+    information: ImmutableList<InformationRadioGroupUiModel>,
+    selectInformation: (InformationRadioGroupUiModel) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val (first, last) = information
+
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(NWKTheme.spacing.space300),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        InformationSelectRadioButton(
+            modifier = Modifier.weight(1f),
+            text = first.text,
+            isSelected = first.isSelected,
+            onClick = {
+                selectInformation(first)
+            },
+        )
+        Text(
+            text = "vs",
+            style = NWKTheme.typography.body1.copy(
+                fontWeight = FontWeight.W500,
+                color = NWKTheme.color.Semantic.Text.body,
+            ),
+        )
+        InformationSelectRadioButton(
+            modifier = Modifier.weight(1f),
+            text = last.text,
+            isSelected = last.isSelected,
+            onClick = { selectInformation(last) },
+        )
+    }
+}
 
 @Composable
 internal fun InformationSelectRadioButton(
@@ -50,7 +116,7 @@ internal fun InformationSelectRadioButton(
     ) {
         Text(
             modifier = Modifier
-                .widthIn(min = 108.dp)
+                .wrapContentWidth()
                 .padding(InformationSelectRadioButtonDefaults.contentPadding),
             text = text,
             style = NWKTheme.typography.subTitle1.copy(
@@ -64,8 +130,23 @@ internal fun InformationSelectRadioButton(
 
 @Preview
 @Composable
+private fun InformationSelectRadioGroupPreview(
+    @PreviewParameter(PreviewInformationSelectRadioGroupProvider::class) informations: ImmutableList<InformationRadioGroupUiModel>,
+) {
+    NWKTheme {
+        Box(modifier = Modifier.background(NWKTheme.color.Neutral.white)) {
+            InformationSelectRadioGroup(
+                information = informations,
+                selectInformation = {},
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
 private fun InformationSelectRadioButtonPreview(
-    @PreviewParameter(PreviewInformationSelectRadioButtonProvider::class) information: SelectedInformationUiModel,
+    @PreviewParameter(PreviewInformationSelectRadioButtonProvider::class) information: InformationRadioGroupUiModel,
 ) {
     NWKTheme {
         InformationSelectRadioButton(

--- a/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/component/button/InformationSelectRadioButton.kt
+++ b/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/component/button/InformationSelectRadioButton.kt
@@ -14,6 +14,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -45,10 +46,12 @@ internal fun InformationSelectRadioGroupContent(
         verticalArrangement = Arrangement.spacedBy(NWKTheme.spacing.space300),
     ) {
         information.forEach { (row, informationList) ->
-            InformationSelectRadioGroup(
-                information = informationList,
-                selectInformation = { selectInformation(row, it) },
-            )
+            key(informationList) {
+                InformationSelectRadioGroup(
+                    information = informationList,
+                    selectInformation = { selectInformation(row, it) },
+                )
+            }
         }
     }
 }

--- a/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/component/button/InformationSelectRadioButton.kt
+++ b/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/component/button/InformationSelectRadioButton.kt
@@ -1,0 +1,77 @@
+package team.noweekend.feature.create.vacation.information.component.button
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import team.noweekend.core.design.system.foundation.theme.NWKTheme
+import team.noweekend.feature.create.vacation.information.component.button.defaults.InformationSelectRadioButtonColors
+import team.noweekend.feature.create.vacation.information.component.button.defaults.InformationSelectRadioButtonDefaults
+import team.noweekend.feature.create.vacation.information.component.button.preview.PreviewInformationSelectRadioButtonProvider
+import team.noweekend.feature.create.vacation.information.model.SelectedInformationUiModel
+
+@Composable
+internal fun InformationSelectRadioButton(
+    text: String,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    colors: InformationSelectRadioButtonColors = InformationSelectRadioButtonDefaults.colors(),
+) {
+    val contentColor: Color by colors.contentColor(isSelected)
+    val borderStroke: BorderStroke by InformationSelectRadioButtonDefaults.borderStroke(isSelected)
+
+    Surface(
+        modifier = modifier
+            .semantics { role = Role.RadioButton }
+            .clip(NWKTheme.radius.borderRadius400)
+            .clickable(
+                enabled = true,
+                onClick = onClick,
+            ),
+        shape = InformationSelectRadioButtonDefaults.shape,
+        color = InformationSelectRadioButtonDefaults.backgroundColor,
+        contentColor = contentColor,
+        border = borderStroke,
+    ) {
+        Text(
+            modifier = Modifier
+                .widthIn(min = 108.dp)
+                .padding(InformationSelectRadioButtonDefaults.contentPadding),
+            text = text,
+            style = NWKTheme.typography.subTitle1.copy(
+                color = contentColor,
+            ),
+            maxLines = 1,
+            textAlign = TextAlign.Center,
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun InformationSelectRadioButtonPreview(
+    @PreviewParameter(PreviewInformationSelectRadioButtonProvider::class) information: SelectedInformationUiModel,
+) {
+    NWKTheme {
+        InformationSelectRadioButton(
+            text = information.text,
+            isSelected = information.isSelected,
+            onClick = {},
+        )
+    }
+}

--- a/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/component/button/defaults/InformationSelectRadioButtonColors.kt
+++ b/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/component/button/defaults/InformationSelectRadioButtonColors.kt
@@ -1,0 +1,43 @@
+package team.noweekend.feature.create.vacation.information.component.button.defaults
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.graphics.Color
+
+@Immutable
+class InformationSelectRadioButtonColors(
+    private val contentColor: Color,
+    private val borderColor: Color,
+    private val unselectedContentColor: Color,
+    private val unselectedBorderColor: Color,
+) {
+
+    @Composable
+    internal fun contentColor(selected: Boolean): State<Color> {
+        return rememberUpdatedState(
+            newValue = if (selected) contentColor else unselectedContentColor,
+        )
+    }
+
+    @Composable
+    internal fun borderColor(selected: Boolean): State<Color> {
+        return rememberUpdatedState(
+            newValue = if (selected) borderColor else unselectedBorderColor,
+        )
+    }
+
+    override fun equals(other: Any?): Boolean {
+        return this === other || (other is InformationSelectRadioButtonColors &&
+            contentColor == other.contentColor &&
+            borderColor == other.borderColor &&
+            unselectedContentColor == other.unselectedContentColor &&
+            unselectedBorderColor == other.unselectedBorderColor
+            )
+    }
+
+    override fun hashCode(): Int {
+        return arrayOf(contentColor, borderColor, unselectedContentColor, unselectedBorderColor).contentHashCode()
+    }
+}

--- a/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/component/button/defaults/InformationSelectRadioButtonDefaults.kt
+++ b/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/component/button/defaults/InformationSelectRadioButtonDefaults.kt
@@ -18,7 +18,7 @@ object InformationSelectRadioButtonDefaults {
     val contentPadding: PaddingValues
         @Composable get() = PaddingValues(
             horizontal = NWKTheme.spacing.space150,
-            vertical = NWKTheme.spacing.space100,
+            vertical = NWKTheme.spacing.space150,
         )
 
     val backgroundColor: Color

--- a/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/component/button/defaults/InformationSelectRadioButtonDefaults.kt
+++ b/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/component/button/defaults/InformationSelectRadioButtonDefaults.kt
@@ -1,0 +1,51 @@
+package team.noweekend.feature.create.vacation.information.component.button.defaults
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.shape.CornerBasedShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import team.noweekend.core.design.system.foundation.theme.NWKTheme
+
+object InformationSelectRadioButtonDefaults {
+
+    val shape: CornerBasedShape
+        @Composable get() = NWKTheme.radius.borderRadius400
+
+    val contentPadding: PaddingValues
+        @Composable get() = PaddingValues(
+            horizontal = NWKTheme.spacing.space150,
+            vertical = NWKTheme.spacing.space100,
+        )
+
+    val backgroundColor: Color
+        @Composable get() = NWKTheme.color.Neutral.white
+
+    @Composable
+    fun borderStroke(selected: Boolean): State<BorderStroke> {
+        return rememberUpdatedState(
+            newValue = BorderStroke(
+                width = 1.dp,
+                color = colors().borderColor(selected).value,
+            ),
+        )
+    }
+
+    @Composable
+    fun colors(
+        contentColor: Color = NWKTheme.color.Neutral.black,
+        borderColor: Color = NWKTheme.color.Toast.toast500,
+        unselectedContentColor: Color = NWKTheme.color.Semantic.Text.disabled,
+        unselectedBorderColor: Color = NWKTheme.color.Semantic.Border.border01,
+    ): InformationSelectRadioButtonColors {
+        return InformationSelectRadioButtonColors(
+            contentColor = contentColor,
+            borderColor = borderColor,
+            unselectedContentColor = unselectedContentColor,
+            unselectedBorderColor = unselectedBorderColor,
+        )
+    }
+}

--- a/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/component/button/preview/PreviewInformationSelectRadioButtonProvider.kt
+++ b/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/component/button/preview/PreviewInformationSelectRadioButtonProvider.kt
@@ -1,0 +1,26 @@
+package team.noweekend.feature.create.vacation.information.component.button.preview
+
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import team.noweekend.feature.create.vacation.information.model.SelectedInformationUiModel
+
+internal class PreviewInformationSelectRadioButtonProvider : PreviewParameterProvider<SelectedInformationUiModel> {
+    override val values: Sequence<SelectedInformationUiModel>
+        get() = sequenceOf(
+            SelectedInformationUiModel(
+                text = "계획형",
+                isSelected = true,
+            ),
+            SelectedInformationUiModel(
+                text = "즉흥 자유형",
+                isSelected = true,
+            ),
+            SelectedInformationUiModel(
+                text = "야외 활동",
+                isSelected = false,
+            ),
+            SelectedInformationUiModel(
+                text = "집콕",
+                isSelected = false,
+            ),
+        )
+}

--- a/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/component/button/preview/PreviewInformationSelectRadioButtonProvider.kt
+++ b/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/component/button/preview/PreviewInformationSelectRadioButtonProvider.kt
@@ -1,26 +1,45 @@
 package team.noweekend.feature.create.vacation.information.component.button.preview
 
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
-import team.noweekend.feature.create.vacation.information.model.SelectedInformationUiModel
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import team.noweekend.feature.create.vacation.information.model.InformationRadioGroupUiModel
 
-internal class PreviewInformationSelectRadioButtonProvider : PreviewParameterProvider<SelectedInformationUiModel> {
-    override val values: Sequence<SelectedInformationUiModel>
+internal class PreviewInformationSelectRadioButtonProvider : PreviewParameterProvider<InformationRadioGroupUiModel> {
+    override val values: Sequence<InformationRadioGroupUiModel>
         get() = sequenceOf(
-            SelectedInformationUiModel(
+            InformationRadioGroupUiModel(
                 text = "계획형",
                 isSelected = true,
             ),
-            SelectedInformationUiModel(
+            InformationRadioGroupUiModel(
                 text = "즉흥 자유형",
                 isSelected = true,
             ),
-            SelectedInformationUiModel(
+            InformationRadioGroupUiModel(
                 text = "야외 활동",
                 isSelected = false,
             ),
-            SelectedInformationUiModel(
+            InformationRadioGroupUiModel(
                 text = "집콕",
                 isSelected = false,
+            ),
+        )
+}
+
+internal class PreviewInformationSelectRadioGroupProvider :
+    PreviewParameterProvider<ImmutableList<InformationRadioGroupUiModel>> {
+    override val values: Sequence<ImmutableList<InformationRadioGroupUiModel>>
+        get() = sequenceOf(
+            persistentListOf(
+                InformationRadioGroupUiModel(
+                    text = "계획형",
+                    isSelected = true,
+                ),
+                InformationRadioGroupUiModel(
+                    text = "즉흥 자유형",
+                    isSelected = false,
+                ),
             ),
         )
 }

--- a/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/model/InformationRadioGroupUiModel.kt
+++ b/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/model/InformationRadioGroupUiModel.kt
@@ -1,6 +1,6 @@
 package team.noweekend.feature.create.vacation.information.model
 
-data class SelectedInformationUiModel(
+data class InformationRadioGroupUiModel(
     val text: String,
     val isSelected: Boolean,
 )

--- a/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/model/SelectedInformationUiModel.kt
+++ b/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/model/SelectedInformationUiModel.kt
@@ -1,0 +1,6 @@
+package team.noweekend.feature.create.vacation.information.model
+
+data class SelectedInformationUiModel(
+    val text: String,
+    val isSelected: Boolean,
+)

--- a/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/mvi/InformationIntent.kt
+++ b/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/mvi/InformationIntent.kt
@@ -1,0 +1,8 @@
+package team.noweekend.feature.create.vacation.information.mvi
+
+import team.noweekend.core.common.android.mvi.Intent
+
+sealed interface InformationIntent : Intent {
+    data object ClickBackButton : InformationIntent
+    data object ClickNextButton : InformationIntent
+}

--- a/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/mvi/InformationIntent.kt
+++ b/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/mvi/InformationIntent.kt
@@ -1,8 +1,13 @@
 package team.noweekend.feature.create.vacation.information.mvi
 
 import team.noweekend.core.common.android.mvi.Intent
+import team.noweekend.feature.create.vacation.information.model.InformationRadioGroupUiModel
 
 sealed interface InformationIntent : Intent {
     data object ClickBackButton : InformationIntent
     data object ClickNextButton : InformationIntent
+    data class SelectInformation(
+        val row: Int,
+        val information: InformationRadioGroupUiModel,
+    ) : InformationIntent
 }

--- a/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/mvi/InformationSideEffect.kt
+++ b/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/mvi/InformationSideEffect.kt
@@ -1,0 +1,8 @@
+package team.noweekend.feature.create.vacation.information.mvi
+
+import team.noweekend.core.common.android.mvi.SideEffect
+
+sealed interface InformationSideEffect : SideEffect {
+    data object NavigateToHistoryBack : InformationSideEffect
+    data object NavigateToVacationRecommendation : InformationSideEffect
+}

--- a/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/mvi/InformationSideEffectHandler.kt
+++ b/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/mvi/InformationSideEffectHandler.kt
@@ -1,0 +1,29 @@
+package team.noweekend.feature.create.vacation.information.mvi
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import team.noweekend.core.common.android.mvi.SideEffect
+import team.noweekend.core.common.android.mvi.SideEffectHandler
+
+@Composable
+internal fun rememberInformationSideEffectHandler(
+    navigateToHistoryBack: () -> Unit,
+    navigateToVacationRecommendation: () -> Unit,
+): InformationSideEffectHandler = remember {
+    InformationSideEffectHandler(
+        navigateToHistoryBack = navigateToHistoryBack,
+        navigateToVacationRecommendation = navigateToVacationRecommendation,
+    )
+}
+
+internal class InformationSideEffectHandler(
+    private val navigateToHistoryBack: () -> Unit,
+    private val navigateToVacationRecommendation: () -> Unit,
+) : SideEffectHandler<SideEffect> {
+    override fun handleSideEffect(sideEffect: SideEffect) {
+        when (sideEffect) {
+            InformationSideEffect.NavigateToHistoryBack -> navigateToHistoryBack()
+            InformationSideEffect.NavigateToVacationRecommendation -> navigateToVacationRecommendation()
+        }
+    }
+}

--- a/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/mvi/InformationUiState.kt
+++ b/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/mvi/InformationUiState.kt
@@ -1,6 +1,10 @@
 package team.noweekend.feature.create.vacation.information.mvi
 
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.remember
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.ImmutableMap
 import kotlinx.collections.immutable.persistentListOf
@@ -13,7 +17,14 @@ data class InformationUiState(
     val isLoading: Boolean,
     val information: ImmutableMap<Int, ImmutableList<InformationRadioGroupUiModel>>,
 ) : UiState {
-    val isButtonEnabled: Boolean = false
+    val isButtonEnabled: State<Boolean>
+        @Composable get() = remember(information) {
+            val enableButton: Boolean = information.all { (_, information) ->
+                information.count { it.isSelected } == 1
+            }
+            derivedStateOf { enableButton }
+        }
+
 
     companion object {
         val INITIAL_STATE: InformationUiState = InformationUiState(

--- a/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/mvi/InformationUiState.kt
+++ b/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/mvi/InformationUiState.kt
@@ -1,21 +1,135 @@
 package team.noweekend.feature.create.vacation.information.mvi
 
 import androidx.compose.runtime.Stable
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.ImmutableMap
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.persistentMapOf
 import team.noweekend.core.common.android.mvi.UiState
+import team.noweekend.feature.create.vacation.information.model.InformationRadioGroupUiModel
 
 @Stable
 data class InformationUiState(
     val isLoading: Boolean,
+    val information: ImmutableMap<Int, ImmutableList<InformationRadioGroupUiModel>>,
 ) : UiState {
     val isButtonEnabled: Boolean = false
 
     companion object {
         val INITIAL_STATE: InformationUiState = InformationUiState(
             isLoading = false,
+            information = persistentMapOf(
+                Pair(
+                    1,
+                    persistentListOf(
+                        InformationRadioGroupUiModel(
+                            text = "계획형",
+                            isSelected = false,
+                        ),
+                        InformationRadioGroupUiModel(
+                            text = "즉흥 자유형",
+                            isSelected = false,
+                        ),
+                    ),
+                ),
+                Pair(
+                    2,
+                    persistentListOf(
+                        InformationRadioGroupUiModel(
+                            text = "야외 활동",
+                            isSelected = false,
+                        ),
+                        InformationRadioGroupUiModel(
+                            text = "집콕",
+                            isSelected = false,
+                        ),
+                    ),
+                ),
+                Pair(
+                    3,
+                    persistentListOf(
+                        InformationRadioGroupUiModel(
+                            text = "휴식",
+                            isSelected = false,
+                        ),
+                        InformationRadioGroupUiModel(
+                            text = "자기계발",
+                            isSelected = false,
+                        ),
+                    ),
+                ),
+                Pair(
+                    4,
+                    persistentListOf(
+                        InformationRadioGroupUiModel(
+                            text = "음식",
+                            isSelected = false,
+                        ),
+                        InformationRadioGroupUiModel(
+                            text = "관광",
+                            isSelected = false,
+                        ),
+                    ),
+                ),
+            ),
         )
 
         val DUMMY_STATE: InformationUiState = InformationUiState(
             isLoading = false,
+            information = persistentMapOf(
+                Pair(
+                    1,
+                    persistentListOf(
+                        InformationRadioGroupUiModel(
+                            text = "계획형",
+                            isSelected = false,
+                        ),
+                        InformationRadioGroupUiModel(
+                            text = "즉흥 자유형",
+                            isSelected = false,
+                        ),
+                    ),
+                ),
+                Pair(
+                    2,
+                    persistentListOf(
+                        InformationRadioGroupUiModel(
+                            text = "야외 활동",
+                            isSelected = false,
+                        ),
+                        InformationRadioGroupUiModel(
+                            text = "집콕",
+                            isSelected = false,
+                        ),
+                    ),
+                ),
+                Pair(
+                    3,
+                    persistentListOf(
+                        InformationRadioGroupUiModel(
+                            text = "휴식",
+                            isSelected = false,
+                        ),
+                        InformationRadioGroupUiModel(
+                            text = "자기계발",
+                            isSelected = false,
+                        ),
+                    ),
+                ),
+                Pair(
+                    4,
+                    persistentListOf(
+                        InformationRadioGroupUiModel(
+                            text = "음식",
+                            isSelected = false,
+                        ),
+                        InformationRadioGroupUiModel(
+                            text = "관광",
+                            isSelected = false,
+                        ),
+                    ),
+                ),
+            ),
         )
     }
 }

--- a/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/mvi/InformationUiState.kt
+++ b/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/mvi/InformationUiState.kt
@@ -1,0 +1,21 @@
+package team.noweekend.feature.create.vacation.information.mvi
+
+import androidx.compose.runtime.Stable
+import team.noweekend.core.common.android.mvi.UiState
+
+@Stable
+data class InformationUiState(
+    val isLoading: Boolean,
+) : UiState {
+    val isButtonEnabled: Boolean = false
+
+    companion object {
+        val INITIAL_STATE: InformationUiState = InformationUiState(
+            isLoading = false,
+        )
+
+        val DUMMY_STATE: InformationUiState = InformationUiState(
+            isLoading = false,
+        )
+    }
+}

--- a/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/mvi/InformationUiState.kt
+++ b/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/mvi/InformationUiState.kt
@@ -20,8 +20,9 @@ data class InformationUiState(
     val isButtonEnabled: State<Boolean>
         @Composable get() = remember(information) {
             val enableButton: Boolean = information.all { (_, information) ->
-                information.count { it.isSelected } == 1
+                information.any { it.isSelected }
             }
+
             derivedStateOf { enableButton }
         }
 

--- a/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/mvi/InformationUiState.kt
+++ b/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/mvi/InformationUiState.kt
@@ -15,12 +15,12 @@ import team.noweekend.feature.create.vacation.information.model.InformationRadio
 @Stable
 data class InformationUiState(
     val isLoading: Boolean,
-    val information: ImmutableMap<Int, ImmutableList<InformationRadioGroupUiModel>>,
+    val informationData: ImmutableMap<Int, ImmutableList<InformationRadioGroupUiModel>>,
 ) : UiState {
     val isButtonEnabled: State<Boolean>
-        @Composable get() = remember(information) {
-            val enableButton: Boolean = information.all { (_, information) ->
-                information.any { it.isSelected }
+        @Composable get() = remember(informationData) {
+            val enableButton: Boolean = informationData.all { (_, informationRow) ->
+                informationRow.any { it.isSelected }
             }
 
             derivedStateOf { enableButton }
@@ -30,7 +30,7 @@ data class InformationUiState(
     companion object {
         val INITIAL_STATE: InformationUiState = InformationUiState(
             isLoading = false,
-            information = persistentMapOf(
+            informationData = persistentMapOf(
                 Pair(
                     1,
                     persistentListOf(
@@ -88,7 +88,7 @@ data class InformationUiState(
 
         val DUMMY_STATE: InformationUiState = InformationUiState(
             isLoading = false,
-            information = persistentMapOf(
+            informationData = persistentMapOf(
                 Pair(
                     1,
                     persistentListOf(

--- a/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/mvi/InformationViewModel.kt
+++ b/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/mvi/InformationViewModel.kt
@@ -1,8 +1,12 @@
 package team.noweekend.feature.create.vacation.information.mvi
 
+import android.util.Log
 import androidx.lifecycle.SavedStateHandle
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.toImmutableList
+import kotlinx.collections.immutable.toImmutableMap
 import team.noweekend.core.common.android.base.MVIViewModel
+import team.noweekend.feature.create.vacation.information.model.InformationRadioGroupUiModel
 import javax.inject.Inject
 
 @HiltViewModel
@@ -19,8 +23,27 @@ class InformationViewModel @Inject constructor(
 
     override suspend fun handleIntent(intent: InformationIntent) {
         when (intent) {
-            InformationIntent.ClickBackButton -> navigateToHistoryBack()
-            InformationIntent.ClickNextButton -> navigateToRecommendResult()
+            is InformationIntent.ClickBackButton -> navigateToHistoryBack()
+            is InformationIntent.ClickNextButton -> navigateToRecommendResult()
+            is InformationIntent.SelectInformation -> updateInformationCheckStatus(intent.row, intent.information)
+        }
+    }
+
+    private fun updateInformationCheckStatus(selectedRow: Int, information: InformationRadioGroupUiModel) {
+        val updatedInformation = currentState.information.map { (row, informationList) ->
+            if (row == selectedRow) {
+                row to informationList.map { uiModel ->
+                    uiModel.copy(isSelected = uiModel == information)
+                }.toImmutableList()
+            } else {
+                row to informationList
+            }
+        }.toMap().toImmutableMap()
+
+        reduce {
+            copy(
+                information = updatedInformation,
+            )
         }
     }
 

--- a/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/mvi/InformationViewModel.kt
+++ b/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/mvi/InformationViewModel.kt
@@ -1,6 +1,5 @@
 package team.noweekend.feature.create.vacation.information.mvi
 
-import android.util.Log
 import androidx.lifecycle.SavedStateHandle
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.toImmutableList
@@ -29,20 +28,24 @@ class InformationViewModel @Inject constructor(
         }
     }
 
-    private fun updateInformationCheckStatus(selectedRow: Int, information: InformationRadioGroupUiModel) {
-        val updatedInformation = currentState.information.map { (row, informationList) ->
-            if (row == selectedRow) {
-                row to informationList.map { uiModel ->
-                    uiModel.copy(isSelected = uiModel == information)
-                }.toImmutableList()
-            } else {
-                row to informationList
-            }
-        }.toMap().toImmutableMap()
+    private fun updateInformationCheckStatus(
+        selectedRow: Int,
+        information: InformationRadioGroupUiModel,
+    ) {
+        val updatedInformation = currentState.informationData
+            .map { (row, informationList) ->
+                if (row == selectedRow) {
+                    row to informationList.map { uiModel ->
+                        uiModel.copy(isSelected = uiModel == information)
+                    }.toImmutableList()
+                } else {
+                    row to informationList
+                }
+            }.toMap().toImmutableMap()
 
         reduce {
             copy(
-                information = updatedInformation,
+                informationData = updatedInformation,
             )
         }
     }

--- a/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/mvi/InformationViewModel.kt
+++ b/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/mvi/InformationViewModel.kt
@@ -1,0 +1,34 @@
+package team.noweekend.feature.create.vacation.information.mvi
+
+import androidx.lifecycle.SavedStateHandle
+import dagger.hilt.android.lifecycle.HiltViewModel
+import team.noweekend.core.common.android.base.MVIViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class InformationViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+) : MVIViewModel<InformationIntent, InformationSideEffect, InformationUiState>(
+    savedStateHandle = savedStateHandle,
+) {
+    override fun createInitialState(savedStateHandle: SavedStateHandle): InformationUiState {
+        return InformationUiState.DUMMY_STATE
+    }
+
+    override fun handleClientException(throwable: Throwable) {}
+
+    override suspend fun handleIntent(intent: InformationIntent) {
+        when (intent) {
+            InformationIntent.ClickBackButton -> navigateToHistoryBack()
+            InformationIntent.ClickNextButton -> navigateToRecommendResult()
+        }
+    }
+
+    private fun navigateToHistoryBack() = execute {
+        postSideEffect(InformationSideEffect.NavigateToHistoryBack)
+    }
+
+    private fun navigateToRecommendResult() = execute {
+        postSideEffect(InformationSideEffect.NavigateToVacationRecommendation)
+    }
+}

--- a/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/navigation/InformationNavigation.kt
+++ b/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/navigation/InformationNavigation.kt
@@ -10,8 +10,14 @@ internal fun NavController.navigateToInformation() {
     navigate(CreateVacation.Information)
 }
 
-internal fun NavGraphBuilder.informationGraph() {
+internal fun NavGraphBuilder.informationGraph(
+    navigateToHistoryBack: () -> Unit,
+    navigateToVacationRecommendation: () -> Unit,
+) {
     composable<CreateVacation.Information>{
-        InformationRoute()
+        InformationRoute(
+            navigateToHistoryBack = navigateToHistoryBack,
+            navigateToVacationRecommendation = navigateToVacationRecommendation,
+        )
     }
 }

--- a/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/screen/InformationRoute.kt
+++ b/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/screen/InformationRoute.kt
@@ -2,14 +2,12 @@ package team.noweekend.feature.create.vacation.information.screen
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.flow.collectLatest
 import team.noweekend.feature.create.vacation.information.mvi.InformationIntent
 import team.noweekend.feature.create.vacation.information.mvi.InformationSideEffectHandler
-import team.noweekend.feature.create.vacation.information.mvi.InformationUiState
 import team.noweekend.feature.create.vacation.information.mvi.InformationViewModel
 import team.noweekend.feature.create.vacation.information.mvi.rememberInformationSideEffectHandler
 
@@ -20,7 +18,7 @@ internal fun InformationRoute(
     modifier: Modifier = Modifier,
     viewModel: InformationViewModel = hiltViewModel(),
 ) {
-    val uiState: InformationUiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val uiState = viewModel.uiState.collectAsStateWithLifecycle()
     val sideEffectHandler: InformationSideEffectHandler = rememberInformationSideEffectHandler(
         navigateToHistoryBack = navigateToHistoryBack,
         navigateToVacationRecommendation = navigateToVacationRecommendation,

--- a/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/screen/InformationRoute.kt
+++ b/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/screen/InformationRoute.kt
@@ -36,5 +36,8 @@ internal fun InformationRoute(
         uiState = uiState,
         onBackClick = { viewModel.intent(InformationIntent.ClickBackButton) },
         onNextClick = { viewModel.intent(InformationIntent.ClickNextButton) },
+        selectInformation = { row, information ->
+            viewModel.intent(InformationIntent.SelectInformation(row, information))
+        },
     )
 }

--- a/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/screen/InformationRoute.kt
+++ b/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/screen/InformationRoute.kt
@@ -1,11 +1,40 @@
 package team.noweekend.feature.create.vacation.information.screen
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.coroutines.flow.collectLatest
+import team.noweekend.feature.create.vacation.information.mvi.InformationIntent
+import team.noweekend.feature.create.vacation.information.mvi.InformationSideEffectHandler
+import team.noweekend.feature.create.vacation.information.mvi.InformationUiState
+import team.noweekend.feature.create.vacation.information.mvi.InformationViewModel
+import team.noweekend.feature.create.vacation.information.mvi.rememberInformationSideEffectHandler
 
 @Composable
 internal fun InformationRoute(
+    navigateToHistoryBack: () -> Unit,
+    navigateToVacationRecommendation: () -> Unit,
     modifier: Modifier = Modifier,
+    viewModel: InformationViewModel = hiltViewModel(),
 ) {
-    InformationScreen()
+    val uiState: InformationUiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val sideEffectHandler: InformationSideEffectHandler = rememberInformationSideEffectHandler(
+        navigateToHistoryBack = navigateToHistoryBack,
+        navigateToVacationRecommendation = navigateToVacationRecommendation,
+    )
+
+    LaunchedEffect(key1 = Unit) {
+        viewModel.sideEffect.collectLatest { sideEffect ->
+            sideEffectHandler.handleSideEffect(sideEffect)
+        }
+    }
+
+    InformationScreen(
+        uiState = uiState,
+        onBackClick = { viewModel.intent(InformationIntent.ClickBackButton) },
+        onNextClick = { viewModel.intent(InformationIntent.ClickNextButton) },
+    )
 }

--- a/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/screen/InformationScreen.kt
+++ b/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/screen/InformationScreen.kt
@@ -2,8 +2,6 @@ package team.noweekend.feature.create.vacation.information.screen
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.Orientation
-import androidx.compose.foundation.gestures.ScrollableState
-import androidx.compose.foundation.gestures.rememberScrollableState
 import androidx.compose.foundation.gestures.scrollable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -12,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
@@ -93,12 +92,10 @@ private fun InformationScreenContent(
     selectInformation: (Int, InformationRadioGroupUiModel) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val columnScrollState: ScrollableState = rememberScrollableState { it }
-
     Column(
         modifier = modifier
             .fillMaxSize()
-            .scrollable(state = columnScrollState, orientation = Orientation.Vertical),
+            .scrollable(state = rememberScrollState(), orientation = Orientation.Vertical),
     ) {
         Spacer(Modifier.size(NWKTheme.spacing.space600))
         Text(

--- a/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/screen/InformationScreen.kt
+++ b/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/screen/InformationScreen.kt
@@ -78,7 +78,7 @@ internal fun InformationScreen(
                 onClick = onNextClick,
                 text = "다음",
                 type = BoxButtonType.BLACK,
-                enabled = uiState.isButtonEnabled,
+                enabled = uiState.isButtonEnabled.value,
             )
         },
     )

--- a/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/screen/InformationScreen.kt
+++ b/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/screen/InformationScreen.kt
@@ -14,6 +14,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -35,7 +38,7 @@ import team.noweekend.feature.create.vacation.information.mvi.InformationUiState
 
 @Composable
 internal fun InformationScreen(
-    uiState: InformationUiState,
+    uiState: State<InformationUiState>,
     onBackClick: () -> Unit,
     onNextClick: () -> Unit,
     selectInformation: (Int, InformationRadioGroupUiModel) -> Unit,
@@ -63,7 +66,7 @@ internal fun InformationScreen(
                 modifier = Modifier
                     .fillMaxSize()
                     .padding(paddingValues),
-                information = uiState.information,
+                information = uiState.value.information,
                 selectInformation = selectInformation,
             )
         },
@@ -78,7 +81,7 @@ internal fun InformationScreen(
                 onClick = onNextClick,
                 text = "다음",
                 type = BoxButtonType.BLACK,
-                enabled = uiState.isButtonEnabled.value,
+                enabled = uiState.value.isButtonEnabled.value,
             )
         },
     )
@@ -128,12 +131,14 @@ private fun InformationScreenContent(
 @Preview
 @Composable
 private fun InformationScreenPreview() {
+    val uiState = remember { mutableStateOf(InformationUiState.DUMMY_STATE) }
+
     NWKTheme {
         InformationScreen(
-            uiState = InformationUiState.DUMMY_STATE,
+            uiState = uiState,
             onBackClick = {},
             onNextClick = {},
-            selectInformation = { _, _ ->},
+            selectInformation = { _, _ -> },
         )
     }
 }

--- a/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/screen/InformationScreen.kt
+++ b/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/screen/InformationScreen.kt
@@ -1,11 +1,125 @@
 package team.noweekend.feature.create.vacation.information.screen
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.ScrollableState
+import androidx.compose.foundation.gestures.rememberScrollableState
+import androidx.compose.foundation.gestures.scrollable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import team.noweekend.core.design.system.core.component.button.defaults.BoxButtonType
+import team.noweekend.core.design.system.core.component.button.fill.NWKFillButton
+import team.noweekend.core.design.system.core.component.icon.NWKIcon
+import team.noweekend.core.design.system.core.component.scaffold.NWKScaffold
+import team.noweekend.core.design.system.foundation.theme.NWKTheme
+import team.noweekend.core.resource.NWKDrawableResource
+import team.noweekend.core.resource.NWKStringResource
+import team.noweekend.feature.create.vacation.information.mvi.InformationUiState
 
 @Composable
 internal fun InformationScreen(
+    uiState: InformationUiState,
+    onBackClick: () -> Unit,
+    onNextClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    NWKScaffold(
+        modifier = modifier.fillMaxSize(),
+        topBar = {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 12.dp, vertical = 16.dp),
+            ) {
+                NWKIcon(
+                    resourceId = NWKDrawableResource.ChevronLeft,
+                    modifier = Modifier
+                        .size(24.dp)
+                        .clickable(onClick = onBackClick),
+                    tint = NWKTheme.color.Semantic.Text.body,
+                )
+            }
+        },
+        content = { paddingValues ->
+            InformationScreenContent(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues),
+            )
+        },
+        bottomBar = {
+            NWKFillButton(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(
+                        horizontal = 20.dp,
+                        vertical = 8.dp,
+                    ),
+                onClick = onNextClick,
+                text = "다음",
+                type = BoxButtonType.BLACK,
+                enabled = uiState.isButtonEnabled
+            )
+        },
+    )
+}
 
+@Composable
+private fun InformationScreenContent(
+    modifier: Modifier = Modifier,
+) {
+    val columnScrollState: ScrollableState = rememberScrollableState { it }
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .scrollable(state = columnScrollState, orientation = Orientation.Vertical),
+    ) {
+        Spacer(Modifier.size(NWKTheme.spacing.space600))
+        Text(
+            modifier = Modifier.fillMaxWidth(),
+            text = stringResource(NWKStringResource.CreateVacationInformationHeader),
+            style = NWKTheme.typography.heading2.copy(
+                fontWeight = FontWeight.W700,
+                color = NWKTheme.color.Semantic.Text.neutral,
+            ),
+            textAlign = TextAlign.Center,
+        )
+        Spacer(Modifier.size(NWKTheme.spacing.space50))
+        Text(
+            modifier = Modifier.fillMaxWidth(),
+            text = stringResource(NWKStringResource.CreateVacationInformationDescription),
+            style = NWKTheme.typography.body1.copy(
+                fontWeight = FontWeight.W500,
+                color = NWKTheme.color.Semantic.Text.body,
+            ),
+            textAlign = TextAlign.Center,
+        )
+        Spacer(Modifier.size(NWKTheme.spacing.space500))
+    }
+}
+
+@Preview
+@Composable
+private fun InformationScreenPreview() {
+    NWKTheme {
+        InformationScreen(
+            uiState = InformationUiState.DUMMY_STATE,
+            onBackClick = {},
+            onNextClick = {},
+        )
+    }
 }

--- a/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/screen/InformationScreen.kt
+++ b/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/screen/InformationScreen.kt
@@ -65,7 +65,7 @@ internal fun InformationScreen(
                 modifier = Modifier
                     .fillMaxSize()
                     .padding(paddingValues),
-                information = uiState.value.information,
+                informationData = uiState.value.informationData,
                 selectInformation = selectInformation,
             )
         },
@@ -88,7 +88,7 @@ internal fun InformationScreen(
 
 @Composable
 private fun InformationScreenContent(
-    information: ImmutableMap<Int, ImmutableList<InformationRadioGroupUiModel>>,
+    informationData: ImmutableMap<Int, ImmutableList<InformationRadioGroupUiModel>>,
     selectInformation: (Int, InformationRadioGroupUiModel) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -119,7 +119,7 @@ private fun InformationScreenContent(
         )
         Spacer(Modifier.size(NWKTheme.spacing.space500))
         InformationSelectRadioGroupContent(
-            information = information,
+            informationData = informationData,
             selectInformation = selectInformation,
         )
     }

--- a/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/screen/InformationScreen.kt
+++ b/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/information/screen/InformationScreen.kt
@@ -20,6 +20,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.ImmutableMap
 import team.noweekend.core.design.system.core.component.button.defaults.BoxButtonType
 import team.noweekend.core.design.system.core.component.button.fill.NWKFillButton
 import team.noweekend.core.design.system.core.component.icon.NWKIcon
@@ -27,6 +29,8 @@ import team.noweekend.core.design.system.core.component.scaffold.NWKScaffold
 import team.noweekend.core.design.system.foundation.theme.NWKTheme
 import team.noweekend.core.resource.NWKDrawableResource
 import team.noweekend.core.resource.NWKStringResource
+import team.noweekend.feature.create.vacation.information.component.button.InformationSelectRadioGroupContent
+import team.noweekend.feature.create.vacation.information.model.InformationRadioGroupUiModel
 import team.noweekend.feature.create.vacation.information.mvi.InformationUiState
 
 @Composable
@@ -34,6 +38,7 @@ internal fun InformationScreen(
     uiState: InformationUiState,
     onBackClick: () -> Unit,
     onNextClick: () -> Unit,
+    selectInformation: (Int, InformationRadioGroupUiModel) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     NWKScaffold(
@@ -58,6 +63,8 @@ internal fun InformationScreen(
                 modifier = Modifier
                     .fillMaxSize()
                     .padding(paddingValues),
+                information = uiState.information,
+                selectInformation = selectInformation,
             )
         },
         bottomBar = {
@@ -71,7 +78,7 @@ internal fun InformationScreen(
                 onClick = onNextClick,
                 text = "다음",
                 type = BoxButtonType.BLACK,
-                enabled = uiState.isButtonEnabled
+                enabled = uiState.isButtonEnabled,
             )
         },
     )
@@ -79,6 +86,8 @@ internal fun InformationScreen(
 
 @Composable
 private fun InformationScreenContent(
+    information: ImmutableMap<Int, ImmutableList<InformationRadioGroupUiModel>>,
+    selectInformation: (Int, InformationRadioGroupUiModel) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val columnScrollState: ScrollableState = rememberScrollableState { it }
@@ -109,6 +118,10 @@ private fun InformationScreenContent(
             textAlign = TextAlign.Center,
         )
         Spacer(Modifier.size(NWKTheme.spacing.space500))
+        InformationSelectRadioGroupContent(
+            information = information,
+            selectInformation = selectInformation,
+        )
     }
 }
 
@@ -120,6 +133,7 @@ private fun InformationScreenPreview() {
             uiState = InformationUiState.DUMMY_STATE,
             onBackClick = {},
             onNextClick = {},
+            selectInformation = { _, _ ->},
         )
     }
 }


### PR DESCRIPTION
### What is this PR (Required)
- **Issue Number** : close #64 
- **Figma : [정보 선택 UI](https://www.figma.com/design/pUg78T5YTg0Jcz7ozWmL7Z/%F0%9F%90%9D-%EC%93%B8%EB%9E%98%EB%A7%90%EB%9E%98?node-id=2118-8421&m=dev)**

### Changes (Required)
- 라디오버튼 구현
- 연차 추천 정보 선택 UI 구현

### Review Point (Required)
- ViewModel에 있는 updateInformationCheckStatus 로직 한번 봐주세용 더 나은 방식이 있으면 적극 환영입니다!

### Screenshot
| 기능 | 스크린샷 |
| --- | --- |
| GIF | <img src="https://github.com/user-attachments/assets/6000fc23-e197-45bc-a6f0-8ff43ac4fb00" width="300" /> |

### 관련 Reference 자료
-