### PR TITLE
[#88] 서버에서 정의한 Schedule를 Todo로 맵핑

### DIFF
--- a/core/common-kotlin/src/main/java/team/noweekend/core/common/kotlin/extension/LocalTime.kt
+++ b/core/common-kotlin/src/main/java/team/noweekend/core/common/kotlin/extension/LocalTime.kt
@@ -6,7 +6,6 @@ import kotlinx.datetime.toJavaLocalDateTime
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
-
 val LocalTime.Companion.MERIDIEM_HOUR_MINUTE_KR_PATTERN
     get() = "(a) HH:mm"
 
@@ -17,4 +16,3 @@ fun LocalDateTime.toFormattedString(pattern: String): String {
     )
     return javaLocalDateTime.format(formatter)
 }
-

--- a/core/common-kotlin/src/main/java/team/noweekend/core/common/kotlin/extension/LocalTime.kt
+++ b/core/common-kotlin/src/main/java/team/noweekend/core/common/kotlin/extension/LocalTime.kt
@@ -1,0 +1,20 @@
+package team.noweekend.core.common.kotlin.extension
+
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
+import kotlinx.datetime.toJavaLocalDateTime
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+
+val LocalTime.Companion.MERIDIEM_HOUR_MINUTE_KR_PATTERN
+    get() = "(a) HH:mm"
+
+fun LocalDateTime.toFormattedString(pattern: String): String {
+    val javaLocalDateTime = this.toJavaLocalDateTime()
+    val formatter = DateTimeFormatter.ofPattern(pattern).withZone(
+        ZoneId.systemDefault(),
+    )
+    return javaLocalDateTime.format(formatter)
+}
+

--- a/core/common-ui/build.gradle.kts
+++ b/core/common-ui/build.gradle.kts
@@ -12,7 +12,6 @@ dependencies {
     implementation(project(":core:common-android"))
     implementation(project(":core:common-kotlin"))
     implementation(project(":core:design-system"))
-    implementation(project(":core:resource"))
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)

--- a/core/model/src/main/java/team/noweekend/core/model/alarm/AlarmOption.kt
+++ b/core/model/src/main/java/team/noweekend/core/model/alarm/AlarmOption.kt
@@ -1,6 +1,5 @@
 package team.noweekend.core.model.alarm
 
-
 enum class AlarmOption {
     NONE,
     ONE_DAY_BEFORE,

--- a/core/model/src/main/java/team/noweekend/core/model/alarm/AlarmOption.kt
+++ b/core/model/src/main/java/team/noweekend/core/model/alarm/AlarmOption.kt
@@ -1,0 +1,14 @@
+package team.noweekend.core.model.alarm
+
+
+enum class AlarmOption {
+    NONE,
+    ONE_DAY_BEFORE,
+    TWO_HOURS_BEFORE,
+    ONE_HOUR_BEFORE,
+    THIRTY_MINUTES_BEFORE,
+    FIFTEEN_MINUTES_BEFORE,
+    FIVE_MINUTES_BEFORE,
+    ONE_MINUTE_BEFORE,
+    ;
+}

--- a/core/model/src/main/java/team/noweekend/core/model/alarm/AlarmOption.kt
+++ b/core/model/src/main/java/team/noweekend/core/model/alarm/AlarmOption.kt
@@ -1,13 +1,47 @@
 package team.noweekend.core.model.alarm
 
+/**
+ * 알람이 울려야하는 시점을 나타내는 옵션
+ */
 enum class AlarmOption {
+    /**
+     * 알람 옵션 없음
+     */
     NONE,
+
+    /**
+     * 스케줄 하루 전
+     */
     ONE_DAY_BEFORE,
+
+    /**
+     * 스케줄 2시간 전
+     */
     TWO_HOURS_BEFORE,
+
+    /**
+     * 스케줄 1시간 전
+     */
     ONE_HOUR_BEFORE,
+
+    /**
+     * 스케줄 30분 전
+     */
     THIRTY_MINUTES_BEFORE,
+
+    /**
+     * 스케줄 15분 전
+     */
     FIFTEEN_MINUTES_BEFORE,
+
+    /**
+     * 스케줄 5분 전
+     */
     FIVE_MINUTES_BEFORE,
+
+    /**
+     * 스케줄 1분 전
+     */
     ONE_MINUTE_BEFORE,
     ;
 }

--- a/core/model/src/main/java/team/noweekend/core/model/schedule/Schedule.kt
+++ b/core/model/src/main/java/team/noweekend/core/model/schedule/Schedule.kt
@@ -1,0 +1,15 @@
+package team.noweekend.core.model.schedule
+
+import team.noweekend.core.model.alarm.AlarmOption
+
+data class Schedule(
+    val id: String,
+    val title: String,
+    val startTime: String,
+    val endTime: String,
+    val category: ScheduleCategory,
+    val temperature: Int,
+    val allDay: Boolean,
+    val completed: Boolean,
+    val alarmOption: AlarmOption,
+)

--- a/core/model/src/main/java/team/noweekend/core/model/schedule/Schedule.kt
+++ b/core/model/src/main/java/team/noweekend/core/model/schedule/Schedule.kt
@@ -2,14 +2,44 @@ package team.noweekend.core.model.schedule
 
 import team.noweekend.core.model.alarm.AlarmOption
 
+/**
+ * 스케줄 정보
+ */
 data class Schedule(
+    /**
+     * 스케줄 구분 id
+     */
     val id: String,
+    /**
+     * 스케줄 제목
+     */
     val title: String,
+    /**
+     * 스케줄 시작 시간
+     */
     val startTime: String,
+    /**
+     * 스케줄 종료 시간
+     */
     val endTime: String,
+    /**
+     * 스케줄 타입 [ScheduleCategory] 중 하나
+     */
     val category: ScheduleCategory,
+    /**
+     * 열정 온도
+     */
     val temperature: Int,
+    /**
+     * 종일 여부
+     */
     val allDay: Boolean,
+    /**
+     * 완료 여부
+     */
     val completed: Boolean,
+    /**
+     * 스케줄 알림 옵션 [AlarmOption] 중 하나
+     */
     val alarmOption: AlarmOption,
 )

--- a/core/model/src/main/java/team/noweekend/core/model/schedule/ScheduleCategory.kt
+++ b/core/model/src/main/java/team/noweekend/core/model/schedule/ScheduleCategory.kt
@@ -1,0 +1,9 @@
+package team.noweekend.core.model.schedule
+
+enum class ScheduleCategory {
+    COMPANY,
+    PERSONAL,
+    ETC,
+    LEAVE,
+    ;
+}

--- a/core/model/src/main/java/team/noweekend/core/model/schedule/ScheduleCategory.kt
+++ b/core/model/src/main/java/team/noweekend/core/model/schedule/ScheduleCategory.kt
@@ -1,9 +1,27 @@
 package team.noweekend.core.model.schedule
 
+/**
+ * 스케줄 타입
+ */
 enum class ScheduleCategory {
+    /**
+     * 회사 일정
+     */
     COMPANY,
+
+    /**
+     * 개인 일정
+     */
     PERSONAL,
+
+    /**
+     * 기타 일정
+     */
     ETC,
+
+    /**
+     * 휴가 일정
+     */
     LEAVE,
     ;
 }

--- a/feature/calendar/src/main/kotlin/team/noweekend/feature/calendar/model/mapper/TodoMapper.kt
+++ b/feature/calendar/src/main/kotlin/team/noweekend/feature/calendar/model/mapper/TodoMapper.kt
@@ -1,0 +1,42 @@
+package team.noweekend.feature.calendar.model.mapper
+
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
+import team.noweekend.core.common.kotlin.extension.MERIDIEM_HOUR_MINUTE_KR_PATTERN
+import team.noweekend.core.common.kotlin.extension.MONTH_DATE_WITH_DAY_OF_WEEK_KR_PATTERN
+import team.noweekend.core.common.kotlin.extension.toFormattedString
+import team.noweekend.core.common.ui.todo.model.Todo
+import team.noweekend.core.common.ui.todo.model.TodoType
+import team.noweekend.core.model.schedule.Schedule
+import team.noweekend.core.model.schedule.ScheduleCategory
+
+fun Schedule.toTodo(): Todo {
+    return Todo(
+        title = this.title,
+        description = getDescription(allDay = this.allDay, startTime = this.startTime),
+        todoType = this.category.toTodoType(),
+        isDone = this.completed,
+    )
+}
+
+fun ScheduleCategory.toTodoType(): TodoType {
+    return when (this) {
+        ScheduleCategory.ETC -> TodoType.Etc()
+        ScheduleCategory.LEAVE -> TodoType.AnnualLeave()
+        ScheduleCategory.COMPANY -> TodoType.Company()
+        ScheduleCategory.PERSONAL -> TodoType.Personal()
+    }
+}
+
+fun getDescription(allDay: Boolean, startTime: String): String {
+    val localDateTime = LocalDateTime.parse(startTime)
+    return if (allDay) {
+        localDateTime.toFormattedString(
+            pattern = LocalDate.MONTH_DATE_WITH_DAY_OF_WEEK_KR_PATTERN,
+        )
+    } else {
+        localDateTime.toFormattedString(pattern = LocalTime.MERIDIEM_HOUR_MINUTE_KR_PATTERN)
+    }
+}
+

--- a/feature/calendar/src/main/kotlin/team/noweekend/feature/calendar/screen/CalendarRoute.kt
+++ b/feature/calendar/src/main/kotlin/team/noweekend/feature/calendar/screen/CalendarRoute.kt
@@ -3,7 +3,6 @@ package team.noweekend.feature.calendar.screen
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf


### PR DESCRIPTION
### What is this PR (Required)
- **Issue Number** : close #88
- **Figma :**
- 기타 관련 문서 :  https://noweekend.store/swagger-ui/index.html#/schedule-controller/getSchedules

### Changes (Required)
- Model-Module 내부 ScheduleModel 정의
- ScheduleModel To TodoUIModel 변환 추가

### Review Point (Required)
- 맵퍼 및 유틸 관련은 LocalTime으로 파일을 생성했는데, 보니까 LocalDateTime도 안에 들어가서 분리할까?
- 기타 Enum class는 우리 서버 레포 안에 들어가서 찾아왔어요

### Screenshot
- none

### 관련 Reference 자료
-