### PR TITLE
[#107] 연차 관리 화면

### DIFF
--- a/core/common-ui/src/main/java/team/noweekend/core/common/ui/vacation/RemainedVacationComponent.kt
+++ b/core/common-ui/src/main/java/team/noweekend/core/common/ui/vacation/RemainedVacationComponent.kt
@@ -20,9 +20,12 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import team.noweekend.core.common.ui.vacation.input.RemainedVacationInputField
+import team.noweekend.core.design.system.core.component.input.status.InputFieldStatus
 import team.noweekend.core.design.system.core.component.toggle.Toggle
+import team.noweekend.core.design.system.core.component.toggle.ToggleState
 import team.noweekend.core.design.system.foundation.theme.NWKTheme
 import team.noweekend.core.resource.NWKStringResource
+import team.noweekend.core.resource.NWKStringResource.InputDateError
 
 @Composable
 fun RemainedVacationComponent(
@@ -33,6 +36,8 @@ fun RemainedVacationComponent(
     onKeyboardAction: () -> Unit,
     onHalfVacationClick: () -> Unit,
     modifier: Modifier = Modifier,
+    isToggleOn: Boolean = false,
+    inputFieldStatus: InputFieldStatus = InputFieldStatus.DEFAULT,
 ) {
     Column(
         modifier = modifier
@@ -49,10 +54,13 @@ fun RemainedVacationComponent(
             vacationState = vacationState,
             onKeyboardAction = onKeyboardAction,
             focusRequester = focusRequester,
+            errorText = stringResource(id = InputDateError),
+            inputTextFieldStatus = inputFieldStatus,
         )
         Spacer(modifier = Modifier.size(24.dp))
         RemainedHalfVacationToggle(
             onHalfVacationClick = onHalfVacationClick,
+            isToggleOn = isToggleOn,
         )
     }
 }
@@ -61,6 +69,7 @@ fun RemainedVacationComponent(
 private fun RemainedHalfVacationToggle(
     onHalfVacationClick: () -> Unit,
     modifier: Modifier = Modifier,
+    isToggleOn: Boolean = false,
 ) {
     Row(
         modifier = modifier.fillMaxWidth(),
@@ -75,6 +84,7 @@ private fun RemainedHalfVacationToggle(
             ),
         )
         Toggle(
+            toggleState = if (isToggleOn) ToggleState.ON else ToggleState.OFF,
             onClickToggle = onHalfVacationClick,
         )
     }

--- a/core/common-ui/src/main/java/team/noweekend/core/common/ui/vacation/input/RemainedVacationInputField.kt
+++ b/core/common-ui/src/main/java/team/noweekend/core/common/ui/vacation/input/RemainedVacationInputField.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import team.noweekend.core.design.system.core.component.input.NWKInputField
+import team.noweekend.core.design.system.core.component.input.status.InputFieldStatus
 import team.noweekend.core.design.system.core.component.input.status.TextInputType
 import team.noweekend.core.resource.NWKStringResource
 
@@ -17,17 +18,20 @@ fun RemainedVacationInputField(
     vacationState: TextFieldState,
     onKeyboardAction: () -> Unit,
     modifier: Modifier = Modifier,
+    errorText: String = "",
+    inputTextFieldStatus: InputFieldStatus = InputFieldStatus.DEFAULT,
     focusRequester: FocusRequester = remember { FocusRequester() },
 ) {
     NWKInputField(
         label = stringResource(NWKStringResource.RemainedVacationInputLabel),
         placeholder = stringResource(NWKStringResource.RemainedVacationInputPlaceholder),
-        errorText = "",
+        errorText = errorText,
         textFieldState = vacationState,
         onKeyboardAction = onKeyboardAction,
         modifier = modifier.fillMaxWidth(),
         focusRequester = focusRequester,
         textInputType = TextInputType.DAY,
+        inputFieldStatus = inputTextFieldStatus,
         keyboardImeAction = ImeAction.Done,
     )
 }

--- a/core/resource/src/main/kotlin/team/noweekend/core/resource/NWKStringResource.kt
+++ b/core/resource/src/main/kotlin/team/noweekend/core/resource/NWKStringResource.kt
@@ -141,4 +141,6 @@ object NWKStringResource {
     val AddTaskInputHint: Int = R.string.input_title_hint
     val AddTaskDetailLabel: Int = R.string.detail_label
     val InputTextSaveLabel: Int = R.string.input_save_label
+
+    val ManageVacation : Int = R.string.manage_vacation
 }

--- a/core/resource/src/main/res/values/strings.xml
+++ b/core/resource/src/main/res/values/strings.xml
@@ -128,7 +128,7 @@
     <string name="nickname_input_error_msg">6글자까지 작성할 수 있어요.</string>
 
     <string name="remained_vacation_header_title">올해 남은 연차를 알려주세요</string>
-    <string name="remained_vacation_header_subtitle">"%1$s일 %1$s시간"</string>
+    <string name="remained_vacation_header_subtitle">"%1$s일 %2$s시간"</string>
     <string name="remained_vacation_input_label">남은 연차</string>
     <string name="remained_vacation_input_placeholder">0</string>
     <string name="remained_half_vacation_description">반차도 남았어요.</string>
@@ -141,6 +141,8 @@
     <string name="input_title_hint">제목</string>
     <string name="detail_label">세부사항</string>
     <string name="input_save_label">저장</string>
+
+    <string name="manage_vacation">연차 관리</string>
 
 
 </resources>

--- a/feature/profile/src/main/kotlin/team/noweekend/feature/profile/component/topbar/ManageVacationTopBar.kt
+++ b/feature/profile/src/main/kotlin/team/noweekend/feature/profile/component/topbar/ManageVacationTopBar.kt
@@ -1,0 +1,53 @@
+package team.noweekend.feature.profile.component.topbar
+
+import androidx.compose.foundation.clickable
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import team.noweekend.core.design.system.core.component.icon.NWKIcon
+import team.noweekend.core.design.system.foundation.theme.NWKTheme
+import team.noweekend.core.resource.NWKDrawableResource.ChevronLeft
+import team.noweekend.core.resource.NWKStringResource.ManageVacation
+import team.noweekend.core.resource.NWKStringResource.ProfileSaveButtonTitle
+import team.noweekend.feature.profile.component.topbar.core.Header
+import team.noweekend.feature.profile.component.topbar.core.HeaderAlignmentType
+
+@Composable
+fun ManageVacationTopBar(
+    onClickSaveButton: () -> Unit,
+    onClickBackButton: () -> Unit,
+    modifier: Modifier = Modifier,
+
+    ) {
+    Header(
+        modifier = modifier,
+        components = arrayOf(
+            { componentModifier ->
+                NWKIcon(
+                    modifier = componentModifier.clickable(onClick = onClickBackButton),
+                    resourceId = ChevronLeft,
+                )
+            },
+            { componentModifier ->
+                Text(
+                    modifier = componentModifier,
+                    text = stringResource(id = ManageVacation),
+                    style = NWKTheme.typography.heading6,
+                    color = NWKTheme.color.Semantic.Text.neutral,
+                    textAlign = TextAlign.Center,
+                )
+            },
+            { componentModifier ->
+                Text(
+                    modifier = componentModifier.clickable(onClick = onClickSaveButton),
+                    text = stringResource(id = ProfileSaveButtonTitle),
+                    style = NWKTheme.typography.heading6,
+                    color = NWKTheme.color.Toast.toast500,
+                )
+            },
+        ),
+        alignment = HeaderAlignmentType.CenterFill,
+    )
+}

--- a/feature/profile/src/main/kotlin/team/noweekend/feature/profile/manageVacation/ManageVacationRoute.kt
+++ b/feature/profile/src/main/kotlin/team/noweekend/feature/profile/manageVacation/ManageVacationRoute.kt
@@ -1,0 +1,18 @@
+package team.noweekend.feature.profile.manageVacation
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+fun ManageVacationRoute(
+    modifier: Modifier = Modifier,
+) {
+    ManageVacationScreen(
+        modifier = Modifier.fillMaxSize(),
+        onClickBackButton = {},
+        onClickSaveButton = {},
+        hours = 4,
+        days = 5,
+    )
+}

--- a/feature/profile/src/main/kotlin/team/noweekend/feature/profile/manageVacation/ManageVacationRoute.kt
+++ b/feature/profile/src/main/kotlin/team/noweekend/feature/profile/manageVacation/ManageVacationRoute.kt
@@ -1,18 +1,46 @@
 package team.noweekend.feature.profile.manageVacation
 
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import team.noweekend.core.design.system.core.component.input.status.InputFieldStatus
 
 @Composable
 fun ManageVacationRoute(
     modifier: Modifier = Modifier,
 ) {
+
+    val days = 15
+    val toggleState =remember { mutableStateOf(false) }
+    val vacationState: TextFieldState = rememberTextFieldState(initialText = days.toString())
+    val inputFieldStatusState = remember {
+        derivedStateOf {
+            val vacationStateText = vacationState.text.toString()
+            if (checkIsAllDigit(vacationStateText)) {
+                InputFieldStatus.DEFAULT
+            } else {
+                InputFieldStatus.ERROR
+            }
+        }
+    }
+
+
     ManageVacationScreen(
         modifier = Modifier.fillMaxSize(),
+        toggleState = toggleState,
         onClickBackButton = {},
         onClickSaveButton = {},
-        hours = 4,
-        days = 5,
+        onHalfVacationClick = {
+            toggleState.value = toggleState.value.not()
+        },
+        vacationState =vacationState,
+        inputFieldStatusState = inputFieldStatusState
     )
 }

--- a/feature/profile/src/main/kotlin/team/noweekend/feature/profile/manageVacation/ManageVacationScreen.kt
+++ b/feature/profile/src/main/kotlin/team/noweekend/feature/profile/manageVacation/ManageVacationScreen.kt
@@ -1,0 +1,111 @@
+package team.noweekend.feature.profile.manageVacation
+
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.tooling.preview.Preview
+import team.noweekend.core.common.ui.vacation.RemainedVacationComponent
+import team.noweekend.core.design.system.core.component.input.status.InputFieldStatus
+import team.noweekend.core.design.system.core.component.scaffold.NWKScaffold
+import team.noweekend.core.design.system.foundation.theme.NWKTheme
+import team.noweekend.feature.profile.component.topbar.ManageVacationTopBar
+
+@Composable
+fun ManageVacationScreen(
+    onClickBackButton: () -> Unit,
+    onClickSaveButton: () -> Unit,
+    hours: Int,
+    days: Int,
+    modifier: Modifier = Modifier,
+) {
+    val focusRequester = remember { FocusRequester() }
+    var toggleState by remember { mutableStateOf(days != 0) }
+    val hoursWithToggleState = if (toggleState) hours else 0
+    val vacationState: TextFieldState = rememberTextFieldState(initialText = days.toString())
+    val inputFieldStatus by remember {
+        derivedStateOf {
+            val vacationStateText = vacationState.text.toString()
+            if (checkIsAllDigit(vacationStateText)) {
+                InputFieldStatus.DEFAULT
+            } else {
+                InputFieldStatus.ERROR
+            }
+        }
+    }
+    val onlyDigitVacationState by remember{
+        derivedStateOf {
+            vacationState.text.filter { it.isDigit() }.toString().toIntOrNull() ?: 0
+        }
+    }
+
+
+    val focusManager = LocalFocusManager.current
+
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+    }
+
+
+    NWKScaffold(
+        modifier = modifier,
+        topBar = {
+            ManageVacationTopBar(
+                onClickBackButton = onClickBackButton,
+                onClickSaveButton = onClickSaveButton,
+            )
+
+        },
+    ) { paddingValues ->
+        RemainedVacationComponent(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .focusable(),
+            hours = hoursWithToggleState,
+            days = onlyDigitVacationState,
+            vacationState = vacationState,
+            focusRequester = focusRequester,
+            onKeyboardAction = {
+                if(inputFieldStatus != InputFieldStatus.ERROR){
+                    focusManager.clearFocus()
+                }
+
+            },
+            onHalfVacationClick = {
+                toggleState = toggleState.not()
+            },
+            inputFieldStatus = inputFieldStatus,
+            isToggleOn = toggleState,
+        )
+    }
+}
+
+fun checkIsAllDigit(text: String): Boolean {
+    return text.all { it.isDigit() }
+}
+
+@Preview
+@Composable
+private fun PreviewManageVacationScreen() {
+    NWKTheme {
+        ManageVacationScreen(
+            modifier = Modifier.fillMaxSize(),
+            onClickBackButton = {},
+            onClickSaveButton = {},
+            hours = 4,
+            days = 2,
+        )
+    }
+}

--- a/feature/profile/src/main/kotlin/team/noweekend/feature/profile/manageVacation/ManageVacationScreen.kt
+++ b/feature/profile/src/main/kotlin/team/noweekend/feature/profile/manageVacation/ManageVacationScreen.kt
@@ -7,11 +7,10 @@ import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.State
 import androidx.compose.runtime.derivedStateOf
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.platform.LocalFocusManager
@@ -26,25 +25,16 @@ import team.noweekend.feature.profile.component.topbar.ManageVacationTopBar
 fun ManageVacationScreen(
     onClickBackButton: () -> Unit,
     onClickSaveButton: () -> Unit,
-    hours: Int,
-    days: Int,
+    toggleState: State<Boolean>,
+    inputFieldStatusState: State<InputFieldStatus>,
+    onHalfVacationClick: () -> Unit,
+    vacationState: TextFieldState,
     modifier: Modifier = Modifier,
-) {
+
+    ) {
     val focusRequester = remember { FocusRequester() }
-    var toggleState by remember { mutableStateOf(days != 0) }
-    val hoursWithToggleState = if (toggleState) hours else 0
-    val vacationState: TextFieldState = rememberTextFieldState(initialText = days.toString())
-    val inputFieldStatus by remember {
-        derivedStateOf {
-            val vacationStateText = vacationState.text.toString()
-            if (checkIsAllDigit(vacationStateText)) {
-                InputFieldStatus.DEFAULT
-            } else {
-                InputFieldStatus.ERROR
-            }
-        }
-    }
-    val onlyDigitVacationState by remember{
+
+    val onlyDigitVacationState = remember {
         derivedStateOf {
             vacationState.text.filter { it.isDigit() }.toString().toIntOrNull() ?: 0
         }
@@ -73,21 +63,19 @@ fun ManageVacationScreen(
                 .fillMaxSize()
                 .padding(paddingValues)
                 .focusable(),
-            hours = hoursWithToggleState,
-            days = onlyDigitVacationState,
+            hours = if (toggleState.value) 4 else 0,
+            days = onlyDigitVacationState.value,
             vacationState = vacationState,
             focusRequester = focusRequester,
             onKeyboardAction = {
-                if(inputFieldStatus != InputFieldStatus.ERROR){
+                if (inputFieldStatusState.value != InputFieldStatus.ERROR) {
                     focusManager.clearFocus()
                 }
 
             },
-            onHalfVacationClick = {
-                toggleState = toggleState.not()
-            },
-            inputFieldStatus = inputFieldStatus,
-            isToggleOn = toggleState,
+            onHalfVacationClick = onHalfVacationClick,
+            inputFieldStatus = inputFieldStatusState.value,
+            isToggleOn = toggleState.value,
         )
     }
 }
@@ -100,12 +88,31 @@ fun checkIsAllDigit(text: String): Boolean {
 @Composable
 private fun PreviewManageVacationScreen() {
     NWKTheme {
+        val days = 15
+        val toggleState = remember { mutableStateOf(false) }
+        val vacationState: TextFieldState = rememberTextFieldState(initialText = days.toString())
+        val inputFieldStatusState = remember {
+            derivedStateOf {
+                val vacationStateText = vacationState.text.toString()
+                if (checkIsAllDigit(vacationStateText)) {
+                    InputFieldStatus.DEFAULT
+                } else {
+                    InputFieldStatus.ERROR
+                }
+            }
+        }
+
+
         ManageVacationScreen(
             modifier = Modifier.fillMaxSize(),
             onClickBackButton = {},
             onClickSaveButton = {},
-            hours = 4,
-            days = 2,
+            onHalfVacationClick = {
+                toggleState.value = toggleState.value.not()
+            },
+            toggleState = toggleState,
+            vacationState = vacationState,
+            inputFieldStatusState = inputFieldStatusState,
         )
     }
 }


### PR DESCRIPTION
### What is this PR (Required)
- **Issue Number** : close #107
- **Figma :**
- 기타 관련 문서 :

### Changes (Required)
- RemainedVacationInputField에 errorText와 InputTextFieldStatus parameter를 전달

- 반차 상태에 따라서 초기 toggleStatus를 업데이트를 시켜야해서, RemainedHalfVacationToggle에 isToggleOn 추가했어

이거 없으면 아마 toggleState가 업데이트가 안되서 변경이 안됐었을지도??

- paramater를 State로 넘기는데, 외부 컴포넌트까지 RemainedVacationComponent까지 State로 넘기지 않으면, State로 감싸나 안감싸나 똑같아

- 반차 로직은 toggleState에 따라서 4로 보일지 0 으로 보일수도 해두었어


### Review Point (Required)
- KeyboardType.Number를 NumberPassWord으로 변경하면, 숫자만 입력하게 할 수 있는데 그럼 errorText가 의미가 없어지는게 맞아
- 일단은 Number를 이용하되, 필터링이나 숫자로만 이뤄지지 않으면 errorText가 보이도록 처리했어

### Screenshot
| 기능 | 스크린샷 |
| --- | --- |
| mp4 | https://github.com/user-attachments/assets/02964a42-c446-4e94-a0b7-a953afe77523 |


### 관련 Reference 자료
-