### PR TITLE
[#114] schedule api 중 get만 연결

### DIFF
--- a/core/common-kotlin/src/main/java/team/noweekend/core/common/kotlin/extension/CalendarUtils.kt
+++ b/core/common-kotlin/src/main/java/team/noweekend/core/common/kotlin/extension/CalendarUtils.kt
@@ -1,4 +1,4 @@
-package team.noweekend.core.common.ui.calendar.util
+package team.noweekend.core.common.kotlin.extension
 
 import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.DayOfWeek
@@ -7,9 +7,6 @@ import kotlinx.datetime.Month
 import kotlinx.datetime.minus
 import kotlinx.datetime.number
 import kotlinx.datetime.plus
-import team.noweekend.core.common.kotlin.extension.instant
-import team.noweekend.core.common.kotlin.extension.toLocalDate
-import team.noweekend.core.common.kotlin.extension.toLocalDateTime
 
 object CalendarUtils {
 

--- a/core/common-kotlin/src/main/java/team/noweekend/core/common/kotlin/extension/LocalDate.kt
+++ b/core/common-kotlin/src/main/java/team/noweekend/core/common/kotlin/extension/LocalDate.kt
@@ -19,6 +19,9 @@ val LocalDate.Companion.MONTH_DATE_WITH_DAY_OF_WEEK_PATTERN
 val LocalDate.Companion.MONTH_DATE_PATTERN
     get() = "M/dd"
 
+val LocalDate.Companion.YEAR_MONTH_DAY_PATTERN
+    get() = "yyyy-MM-dd"
+
 fun LocalDate.toFormattedString(pattern: String): String {
     return this.toJavaLocalDate().format(DateTimeFormatter.ofPattern(pattern))
 }

--- a/core/common-ui/src/main/java/team/noweekend/core/common/ui/calendar/CalendarDataProvider.kt
+++ b/core/common-ui/src/main/java/team/noweekend/core/common/ui/calendar/CalendarDataProvider.kt
@@ -1,7 +1,5 @@
 package team.noweekend.core.common.ui.calendar
 
-import android.util.Log
-import androidx.annotation.DrawableRes
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.Stable
@@ -18,19 +16,19 @@ import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.DayOfWeek
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.plus
+import team.noweekend.core.common.kotlin.extension.CalendarUtils.firstDayOfMonth
+import team.noweekend.core.common.kotlin.extension.CalendarUtils.lastDayOfMonth
+import team.noweekend.core.common.kotlin.extension.CalendarUtils.minusMonths
+import team.noweekend.core.common.kotlin.extension.CalendarUtils.minusWeeks
+import team.noweekend.core.common.kotlin.extension.CalendarUtils.nextOrSame
+import team.noweekend.core.common.kotlin.extension.CalendarUtils.plusDays
+import team.noweekend.core.common.kotlin.extension.CalendarUtils.plusMonths
+import team.noweekend.core.common.kotlin.extension.CalendarUtils.plusWeeks
+import team.noweekend.core.common.kotlin.extension.CalendarUtils.previousOrSame
 import team.noweekend.core.common.kotlin.extension.now
-import team.noweekend.core.common.ui.calendar.model.DateOfWeek
-import team.noweekend.core.common.ui.calendar.model.WeeksData
-import team.noweekend.core.common.ui.calendar.util.CalendarUtils.firstDayOfMonth
-import team.noweekend.core.common.ui.calendar.util.CalendarUtils.lastDayOfMonth
-import team.noweekend.core.common.ui.calendar.util.CalendarUtils.minusMonths
-import team.noweekend.core.common.ui.calendar.util.CalendarUtils.minusWeeks
-import team.noweekend.core.common.ui.calendar.util.CalendarUtils.nextOrSame
-import team.noweekend.core.common.ui.calendar.util.CalendarUtils.plusDays
-import team.noweekend.core.common.ui.calendar.util.CalendarUtils.plusMonths
-import team.noweekend.core.common.ui.calendar.util.CalendarUtils.plusWeeks
-import team.noweekend.core.common.ui.calendar.util.CalendarUtils.previousOrSame
-import team.noweekend.core.resource.NWKDrawableResource
+import team.noweekend.core.common.ui.calendar.model.CalendarDateOfWeek
+import team.noweekend.core.common.ui.calendar.model.CalendarImageType
+import team.noweekend.core.common.ui.calendar.model.CalendarWeeksData
 
 @Composable
 fun rememberCalendarDataProvider(): CalendarDataProvider {
@@ -40,7 +38,7 @@ fun rememberCalendarDataProvider(): CalendarDataProvider {
 }
 
 @Stable
-class CalendarDataProvider() {
+class CalendarDataProvider {
 
     private val _targetDate: MutableState<LocalDate> = mutableStateOf(LocalDate.now())
 
@@ -54,41 +52,41 @@ class CalendarDataProvider() {
     val calendarDataProviderEventFlow: Flow<CalendarDataProviderEvent> =
         _calendarDataProviderEventChannel.receiveAsFlow()
 
-    val weeksData: SnapshotStateMap<Int, WeeksData> = mutableStateMapOf()
+    val calendarWeeksData: SnapshotStateMap<Int, CalendarWeeksData> = mutableStateMapOf()
 
-    val monthData: SnapshotStateMap<Int, WeeksData> = mutableStateMapOf()
+    val monthData: SnapshotStateMap<Int, CalendarWeeksData> = mutableStateMapOf()
 
     /**
      * 주 데이터 를 반환
      */
-    private fun getWeekDates(startedMonday: LocalDate): WeeksData {
-        return WeeksData(
+    private fun getWeekDates(startedMonday: LocalDate): CalendarWeeksData {
+        return CalendarWeeksData(
             year = startedMonday.year,
             month = startedMonday.monthNumber,
-            dateOfWeeks = (0..6).map { day: Int ->
+            calendarDateOfWeeks = (0..6).map { day: Int ->
                 val localDate: LocalDate = startedMonday.plusDays(day)
-                DateOfWeek(
-                    imageType = ImageType.entries.random(),
+                CalendarDateOfWeek(
+                    calendarImageType = CalendarImageType.entries.random(),
                     localDate = localDate,
                     isCurrentDate = localDate == LocalDate.now(),
                 )
-            }.chunked(7).map { weeks: List<DateOfWeek> -> weeks.toImmutableList() }
+            }.chunked(7).map { weeks: List<CalendarDateOfWeek> -> weeks.toImmutableList() }
                 .toImmutableList(),
         )
     }
 
-    private fun getWeekDates(startedMonday: LocalDate, month: Int): WeeksData {
-        return WeeksData(
+    private fun getWeekDates(startedMonday: LocalDate, month: Int): CalendarWeeksData {
+        return CalendarWeeksData(
             year = startedMonday.year,
             month = month,
-            dateOfWeeks = (0..6).map { day: Int ->
+            calendarDateOfWeeks = (0..6).map { day: Int ->
                 val localDate: LocalDate = startedMonday.plusDays(day)
-                DateOfWeek(
-                    imageType = ImageType.entries.random(),
+                CalendarDateOfWeek(
+                    calendarImageType = CalendarImageType.entries.random(),
                     localDate = localDate,
                     isCurrentDate = localDate == LocalDate.now(),
                 )
-            }.chunked(7).map { weeks: List<DateOfWeek> -> weeks.toImmutableList() }
+            }.chunked(7).map { weeks: List<CalendarDateOfWeek> -> weeks.toImmutableList() }
                 .toImmutableList(),
         )
     }
@@ -103,10 +101,10 @@ class CalendarDataProvider() {
         _targetDate.value = currentDay
         val targetWeekMonday: LocalDate = currentDay.previousOrSame(DayOfWeek.MONDAY)
 
-        weeksData.clear()
-        weeksData[initPage] = getWeekDates(startedMonday = targetWeekMonday, month = currentDay.monthNumber)
-        weeksData[initPage - 1] = getWeekDates(startedMonday = targetWeekMonday.minusWeeks(1))
-        weeksData[initPage + 1] = getWeekDates(startedMonday = targetWeekMonday.plusWeeks(1))
+        calendarWeeksData.clear()
+        calendarWeeksData[initPage] = getWeekDates(startedMonday = targetWeekMonday, month = currentDay.monthNumber)
+        calendarWeeksData[initPage - 1] = getWeekDates(startedMonday = targetWeekMonday.minusWeeks(1))
+        calendarWeeksData[initPage + 1] = getWeekDates(startedMonday = targetWeekMonday.plusWeeks(1))
 
         _calendarDataProviderEventChannel.send(
             element = CalendarDataProviderEvent.CompleteInitWeeksCalendar,
@@ -118,42 +116,34 @@ class CalendarDataProvider() {
      */
     fun updatePreviousWeeksData(currentPage: Int) {
         val offsetPageData =
-            weeksData[currentPage] ?: throw IllegalStateException("offsetPageData $currentPage is null")
+            calendarWeeksData[currentPage] ?: throw IllegalStateException("offsetPageData $currentPage is null")
 
-        val currentWeekMonday: DateOfWeek = offsetPageData.dateOfWeeks.flatten().first()
+        val currentWeekMonday: CalendarDateOfWeek = offsetPageData.calendarDateOfWeeks.flatten().first()
 
         val prevPage = currentPage - 1
-        weeksData[prevPage] = getWeekDates(
+        calendarWeeksData[prevPage] = getWeekDates(
             startedMonday = currentWeekMonday.localDate.minusWeeks(1),
         )
 
         val removeNeededPage = currentPage + 2
-        weeksData.remove(removeNeededPage)?.let { _ ->
-            log("currentPage = $currentPage, $removeNeededPage is removed")
-        }
-
-        log("UpdatePreviousWeeksData\n${weeksData.entries.joinToString("\n") { it.key.toString() + " " + it.value }}")
+        calendarWeeksData.remove(removeNeededPage)
     }
 
     /**
      * 현재 페이지 의 다음 페이지 주 데이터 update
      */
     fun updateNextWeeksData(currentPage: Int) {
-        val offsetPageData = weeksData[currentPage] ?: throw IllegalStateException("offsetPageData is null")
-        val currentWeekMonday: DateOfWeek = offsetPageData.dateOfWeeks.flatten().first()
+        val offsetPageData = calendarWeeksData[currentPage] ?: throw IllegalStateException("offsetPageData is null")
+        val currentWeekMonday: CalendarDateOfWeek = offsetPageData.calendarDateOfWeeks.flatten().first()
 
         val nextPageOffset = currentPage + 1
 
-        weeksData[nextPageOffset] = getWeekDates(
+        calendarWeeksData[nextPageOffset] = getWeekDates(
             startedMonday = currentWeekMonday.localDate.plusWeeks(1),
         )
 
         val removeNeededPage = currentPage - 2
-        weeksData.remove(removeNeededPage)?.let { _ ->
-            log("currentPage = $currentPage, $removeNeededPage is removed")
-        }
-
-        log("UpdateNextWeeksData\n${weeksData.entries.joinToString("\n") { it.key.toString() + " " + it.value }}")
+        calendarWeeksData.remove(removeNeededPage)
     }
 
     /**
@@ -179,11 +169,7 @@ class CalendarDataProvider() {
         monthData[prevPage] = getMonthDates(monthStart = currentMonthLocalDate.minusMonths(1))
 
         val removeNeededPage = currentPage + 2
-        monthData.remove(removeNeededPage)?.let { _ ->
-            log("currentPage = $currentPage, $removeNeededPage is removed")
-        }
-
-        log("UpdatePreviousMonthData\n${monthData.entries.joinToString("\n") { it.key.toString() + " " + it.value }}")
+        monthData.remove(removeNeededPage)
     }
 
     /**
@@ -195,17 +181,13 @@ class CalendarDataProvider() {
         monthData[nextPage] = getMonthDates(monthStart = currentMonthLocalDate.plusMonths(1))
 
         val removeNeededPage = currentPage - 2
-        monthData.remove(removeNeededPage)?.let { _ ->
-            log("currentPage = $currentPage, $removeNeededPage is removed")
-        }
-
-        log("UpdatePreviousMonthData\n${monthData.entries.joinToString("\n") { it.key.toString() + " " + it.value }}")
+        monthData.remove(removeNeededPage)
     }
 
     /**
      * 월의 첫 날이 포함된 주의 월요일부터 마지막 날이 포함된 주의 일요일까지 날짜 리스트 반환
      */
-    private fun getMonthDates(monthStart: LocalDate): WeeksData {
+    private fun getMonthDates(monthStart: LocalDate): CalendarWeeksData {
         /**
          * 주어진 월의 첫 날
          */
@@ -234,17 +216,17 @@ class CalendarDataProvider() {
         }.takeWhile { it <= lastSundayOfWeekContainingLastDay }
             .count()
 
-        return WeeksData(
+        return CalendarWeeksData(
             year = monthStart.year,
             month = monthStart.monthNumber,
-            dateOfWeeks = (0 until daysInPeriod).map { day: Int ->
+            calendarDateOfWeeks = (0 until daysInPeriod).map { day: Int ->
                 val localDate: LocalDate = firstMondayOfWeekContainingFirstDay.plusDays(day)
-                DateOfWeek(
-                    imageType = ImageType.entries.random(),
+                CalendarDateOfWeek(
+                    calendarImageType = CalendarImageType.entries.random(),
                     localDate = localDate,
                     isCurrentDate = localDate == LocalDate.now(),
                 )
-            }.chunked(7).map { weeks: List<DateOfWeek> ->
+            }.chunked(7).map { weeks: List<CalendarDateOfWeek> ->
                 weeks.toImmutableList()
             }.toImmutableList(),
         )
@@ -255,41 +237,19 @@ class CalendarDataProvider() {
      * 월의 시작이 다른 달일 수도 있어 정확한 현재 달의 LocalDate 값을 반환.
      */
     private fun getCurrentMonthLocalDate(currentPage: Int): LocalDate {
-        val currentMonthData: WeeksData = monthData[currentPage] ?: throw IllegalStateException("currentPage is null")
+        val currentMonthData: CalendarWeeksData = monthData[currentPage] ?: throw IllegalStateException(
+            "currentPage is null",
+        )
         val currentMonth: Int = currentMonthData.month
-        val currentMonthLocalDateOfWeek: DateOfWeek =
-            currentMonthData.dateOfWeeks.flatten().first { dateOfWeek: DateOfWeek ->
-                dateOfWeek.localDate.monthNumber == currentMonth
+        val currentMonthLocalCalendarDateOfWeek: CalendarDateOfWeek =
+            currentMonthData.calendarDateOfWeeks.flatten().first { calendarDateOfWeek: CalendarDateOfWeek ->
+                calendarDateOfWeek.localDate.monthNumber == currentMonth
             }
-        return currentMonthLocalDateOfWeek.localDate
-    }
-
-    /**
-     * 현재 선택된 날짜를 update.
-     */
-    fun updateTargetDate(dateOfWeek: DateOfWeek) {
-        _targetDate.value = dateOfWeek.localDate
-    }
-
-    private fun log(message: String, isDebugLevel: Boolean = true) {
-        if (isDebugLevel) {
-            Log.d(TAG, message)
-        } else {
-            Log.e(TAG, message)
-        }
+        return currentMonthLocalCalendarDateOfWeek.localDate
     }
 
     sealed interface CalendarDataProviderEvent {
         data object CompleteInitWeeksCalendar : CalendarDataProviderEvent
         data object CompleteInitMonthCalendar : CalendarDataProviderEvent
-    }
-
-    enum class ImageType(@DrawableRes val id: Int) {
-        NONE(id = NWKDrawableResource.DayTypeNone),
-        FutureSchedule(id = NWKDrawableResource.DayTypeFutureSchedule),
-        BurnOut(id = NWKDrawableResource.DayTypeBurnOut),
-        Rest(id = NWKDrawableResource.DayTypeRest),
-        OverZeroUnderFiftyDegree(id = NWKDrawableResource.DayTypeOverZeroUnderFiftyDegree),
-        OverFiftyUnderSeventyFiveDegree(id = NWKDrawableResource.DayTypeOverFiftyUnderSeventyFiveDegree),
     }
 }

--- a/core/common-ui/src/main/java/team/noweekend/core/common/ui/calendar/component/CalendarDay.kt
+++ b/core/common-ui/src/main/java/team/noweekend/core/common/ui/calendar/component/CalendarDay.kt
@@ -11,6 +11,9 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -21,21 +24,21 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import kotlinx.datetime.LocalDate
 import team.noweekend.core.common.kotlin.extension.now
-import team.noweekend.core.common.ui.calendar.CalendarDataProvider.ImageType
-import team.noweekend.core.common.ui.calendar.model.DateOfWeek
-import team.noweekend.core.common.ui.calendar.state.CalendarPagerState.CalendarMode
+import team.noweekend.core.common.ui.calendar.model.CalendarImageType
+import team.noweekend.core.common.ui.calendar.model.CalendarDateOfWeek
+import team.noweekend.core.common.ui.calendar.model.CalendarMode
 import team.noweekend.core.design.system.foundation.theme.NWKTheme
 
 @Composable
 internal fun CalendarDay(
-    dateOfWeek: DateOfWeek,
+    calendarDateOfWeek: CalendarDateOfWeek,
     calendarMode: CalendarMode,
     calendarDayClickable: Boolean,
     modifier: Modifier = Modifier,
     isSelectedDay: Boolean = false,
     isCurrentMonth: Boolean = false,
     horizontalAlignment: Alignment.Horizontal = Alignment.CenterHorizontally,
-    onClickDateOfWeek: (DateOfWeek) -> Unit = {},
+    onClickDateOfWeek: (CalendarDateOfWeek) -> Unit = {},
 ) {
     val condition = if (calendarMode == CalendarMode.MONTH) {
         if (isCurrentMonth) 1f else 0f
@@ -50,7 +53,7 @@ internal fun CalendarDay(
             .clickable(
                 enabled = (isCurrentMonth || calendarMode == CalendarMode.WEEK) && calendarDayClickable,
             ) {
-                onClickDateOfWeek(dateOfWeek)
+                onClickDateOfWeek(calendarDateOfWeek)
             },
         horizontalAlignment = horizontalAlignment,
     ) {
@@ -66,7 +69,7 @@ internal fun CalendarDay(
             horizontalArrangement = Arrangement.Center,
         ) {
             Text(
-                text = dateOfWeek.localDate.dayOfMonth.toString(),
+                text = calendarDateOfWeek.localDate.dayOfMonth.toString(),
                 color = if (isSelectedDay) {
                     NWKTheme.color.Toast.toast700
                 } else {
@@ -78,7 +81,7 @@ internal fun CalendarDay(
         }
         Image(
             modifier = Modifier.size(41.dp),
-            painter = painterResource(id = dateOfWeek.imageType.id),
+            painter = painterResource(id = calendarDateOfWeek.calendarImageType.id),
             contentDescription = null,
         )
     }
@@ -89,13 +92,13 @@ internal fun CalendarDay(
 private fun PreviewCalendarDay() {
     NWKTheme {
         val targetDate = LocalDate.now()
-        val date = DateOfWeek(
+        val date = CalendarDateOfWeek(
             localDate = targetDate,
-            imageType = ImageType.NONE,
+            calendarImageType = CalendarImageType.NONE,
             isCurrentDate = true,
         )
         CalendarDay(
-            dateOfWeek = date,
+            calendarDateOfWeek = date,
             isSelectedDay = true,
             isCurrentMonth = true,
             calendarMode = CalendarMode.WEEK,

--- a/core/common-ui/src/main/java/team/noweekend/core/common/ui/calendar/component/CalendarDay.kt
+++ b/core/common-ui/src/main/java/team/noweekend/core/common/ui/calendar/component/CalendarDay.kt
@@ -11,9 +11,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.State
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -24,8 +21,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import kotlinx.datetime.LocalDate
 import team.noweekend.core.common.kotlin.extension.now
-import team.noweekend.core.common.ui.calendar.model.CalendarImageType
 import team.noweekend.core.common.ui.calendar.model.CalendarDateOfWeek
+import team.noweekend.core.common.ui.calendar.model.CalendarImageType
 import team.noweekend.core.common.ui.calendar.model.CalendarMode
 import team.noweekend.core.design.system.foundation.theme.NWKTheme
 

--- a/core/common-ui/src/main/java/team/noweekend/core/common/ui/calendar/component/CalendarTypeToggle.kt
+++ b/core/common-ui/src/main/java/team/noweekend/core/common/ui/calendar/component/CalendarTypeToggle.kt
@@ -38,7 +38,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
-import team.noweekend.core.common.ui.calendar.state.CalendarPagerState.CalendarMode
+import team.noweekend.core.common.ui.calendar.model.CalendarMode
 import team.noweekend.core.design.system.foundation.theme.NWKTheme
 import kotlin.math.roundToInt
 

--- a/core/common-ui/src/main/java/team/noweekend/core/common/ui/calendar/component/CalenderItem.kt
+++ b/core/common-ui/src/main/java/team/noweekend/core/common/ui/calendar/component/CalenderItem.kt
@@ -4,20 +4,18 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.State
 import androidx.compose.runtime.key
 import androidx.compose.ui.Modifier
 import kotlinx.datetime.LocalDate
 import team.noweekend.core.common.ui.calendar.model.CalendarDateOfWeek
 import team.noweekend.core.common.ui.calendar.model.CalendarMode
 import team.noweekend.core.common.ui.calendar.model.CalendarWeeksData
-import team.noweekend.core.common.ui.calendar.state.CalendarPagerState
 
 @Composable
 internal fun CalendarItem(
     calendarMode: CalendarMode,
     dataList: CalendarWeeksData,
-    targetDate: State<LocalDate>,
+    targetDate: LocalDate,
     calendarItemClickable: Boolean,
     modifier: Modifier = Modifier,
     onClickDateOfWeek: (CalendarDateOfWeek) -> Unit = {},
@@ -34,7 +32,7 @@ internal fun CalendarItem(
                                 modifier = Modifier.weight(1f),
                                 calendarDateOfWeek = dateOfWeek,
                                 calendarDayClickable = calendarItemClickable,
-                                isSelectedDay = dateOfWeek.localDate == targetDate.value,
+                                isSelectedDay = dateOfWeek.localDate == targetDate,
                                 isCurrentMonth = dateOfWeek.localDate.monthNumber == dataList.month,
                                 calendarMode = calendarMode,
                                 onClickDateOfWeek = onClickDateOfWeek,

--- a/core/common-ui/src/main/java/team/noweekend/core/common/ui/calendar/component/CalenderItem.kt
+++ b/core/common-ui/src/main/java/team/noweekend/core/common/ui/calendar/component/CalenderItem.kt
@@ -8,21 +8,22 @@ import androidx.compose.runtime.State
 import androidx.compose.runtime.key
 import androidx.compose.ui.Modifier
 import kotlinx.datetime.LocalDate
-import team.noweekend.core.common.ui.calendar.model.DateOfWeek
-import team.noweekend.core.common.ui.calendar.model.WeeksData
+import team.noweekend.core.common.ui.calendar.model.CalendarDateOfWeek
+import team.noweekend.core.common.ui.calendar.model.CalendarMode
+import team.noweekend.core.common.ui.calendar.model.CalendarWeeksData
 import team.noweekend.core.common.ui.calendar.state.CalendarPagerState
 
 @Composable
 internal fun CalendarItem(
-    calendarMode: CalendarPagerState.CalendarMode,
-    dataList: WeeksData,
+    calendarMode: CalendarMode,
+    dataList: CalendarWeeksData,
     targetDate: State<LocalDate>,
     calendarItemClickable: Boolean,
     modifier: Modifier = Modifier,
-    onClickDateOfWeek: (DateOfWeek) -> Unit = {},
+    onClickDateOfWeek: (CalendarDateOfWeek) -> Unit = {},
 ) {
     Column(modifier = modifier) {
-        dataList.dateOfWeeks.forEachIndexed { index, dateOfWeeks ->
+        dataList.calendarDateOfWeeks.forEachIndexed { index, dateOfWeeks ->
             key(index) {
                 Row(
                     modifier = Modifier.fillMaxWidth(),
@@ -31,7 +32,7 @@ internal fun CalendarItem(
                         key(dateOfWeek) {
                             CalendarDay(
                                 modifier = Modifier.weight(1f),
-                                dateOfWeek = dateOfWeek,
+                                calendarDateOfWeek = dateOfWeek,
                                 calendarDayClickable = calendarItemClickable,
                                 isSelectedDay = dateOfWeek.localDate == targetDate.value,
                                 isCurrentMonth = dateOfWeek.localDate.monthNumber == dataList.month,

--- a/core/common-ui/src/main/java/team/noweekend/core/common/ui/calendar/component/DayOfWeekBar.kt
+++ b/core/common-ui/src/main/java/team/noweekend/core/common/ui/calendar/component/DayOfWeekBar.kt
@@ -8,7 +8,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
-import team.noweekend.core.common.ui.calendar.model.Day
+import team.noweekend.core.common.ui.calendar.model.CalendarDay
 import team.noweekend.core.design.system.foundation.theme.NWKTheme
 
 @Composable
@@ -19,11 +19,11 @@ internal fun DayOfWeekBar(
     Row(
         modifier = modifier,
     ) {
-        Day.getDays(isMondayStarted = isMondayStarted).forEach { day ->
+        CalendarDay.getDays(isMondayStarted = isMondayStarted).forEach { day ->
             key(day.id) {
                 DayOfWeekBarContent(
                     modifier = Modifier.weight(1f),
-                    day = day,
+                    calendarDay = day,
                 )
             }
         }
@@ -32,13 +32,13 @@ internal fun DayOfWeekBar(
 
 @Composable
 private fun DayOfWeekBarContent(
-    day: Day,
+    calendarDay: CalendarDay,
     modifier: Modifier = Modifier,
 ) {
     Text(
         modifier = modifier,
-        text = stringResource(id = day.id),
-        color = day.color,
+        text = stringResource(id = calendarDay.id),
+        color = calendarDay.color,
         textAlign = TextAlign.Center,
         style = NWKTheme.typography.body3,
     )

--- a/core/common-ui/src/main/java/team/noweekend/core/common/ui/calendar/model/CalendarDateOfWeek.kt
+++ b/core/common-ui/src/main/java/team/noweekend/core/common/ui/calendar/model/CalendarDateOfWeek.kt
@@ -2,11 +2,11 @@ package team.noweekend.core.common.ui.calendar.model
 
 import androidx.compose.runtime.Immutable
 import kotlinx.datetime.LocalDate
-import team.noweekend.core.common.ui.calendar.CalendarDataProvider.ImageType
+
 
 @Immutable
-data class DateOfWeek(
-    val imageType: ImageType,
+data class CalendarDateOfWeek(
+    val calendarImageType: CalendarImageType,
     val localDate: LocalDate,
     val isCurrentDate: Boolean,
 )

--- a/core/common-ui/src/main/java/team/noweekend/core/common/ui/calendar/model/CalendarDateOfWeek.kt
+++ b/core/common-ui/src/main/java/team/noweekend/core/common/ui/calendar/model/CalendarDateOfWeek.kt
@@ -3,7 +3,6 @@ package team.noweekend.core.common.ui.calendar.model
 import androidx.compose.runtime.Immutable
 import kotlinx.datetime.LocalDate
 
-
 @Immutable
 data class CalendarDateOfWeek(
     val calendarImageType: CalendarImageType,

--- a/core/common-ui/src/main/java/team/noweekend/core/common/ui/calendar/model/CalendarDay.kt
+++ b/core/common-ui/src/main/java/team/noweekend/core/common/ui/calendar/model/CalendarDay.kt
@@ -11,7 +11,7 @@ import team.noweekend.core.design.system.foundation.theme.NWKTheme
 import team.noweekend.core.resource.NWKStringResource
 
 @Stable
-sealed interface Day {
+sealed interface CalendarDay {
     val dayId: DayOfWeek
 
     val id: Int
@@ -23,43 +23,43 @@ sealed interface Day {
     data class Sunday(
         override val dayId: DayOfWeek = DayOfWeek.SUNDAY,
         override val id: Int = NWKStringResource.Sunday,
-    ) : Day
+    ) : CalendarDay
 
     data class Monday(
         override val dayId: DayOfWeek = DayOfWeek.MONDAY,
         override val id: Int = NWKStringResource.Monday,
-    ) : Day
+    ) : CalendarDay
 
-    data class TuesDay(
+    data class TuesCalendarDay(
         override val dayId: DayOfWeek = DayOfWeek.TUESDAY,
         override val id: Int = NWKStringResource.Tuesday,
-    ) : Day
+    ) : CalendarDay
 
     data class Wednesday(
         override val dayId: DayOfWeek = DayOfWeek.WEDNESDAY,
         override val id: Int = NWKStringResource.Wednesday,
-    ) : Day
+    ) : CalendarDay
 
     data class Thursday(
         override val dayId: DayOfWeek = DayOfWeek.THURSDAY,
         override val id: Int = NWKStringResource.Thursday,
-    ) : Day
+    ) : CalendarDay
 
     data class Friday(
         override val dayId: DayOfWeek = DayOfWeek.FRIDAY,
         override val id: Int = NWKStringResource.Friday,
-    ) : Day
+    ) : CalendarDay
 
     data class Saturday(
         override val dayId: DayOfWeek = DayOfWeek.SATURDAY,
         override val id: Int = NWKStringResource.Saturday,
-    ) : Day
+    ) : CalendarDay
 
     companion object {
         private val defaultDays = persistentListOf(
             Sunday(),
             Monday(),
-            TuesDay(),
+            TuesCalendarDay(),
             Wednesday(),
             Thursday(),
             Friday(),
@@ -68,7 +68,7 @@ sealed interface Day {
 
         private val monthDayStartedDays = persistentListOf(
             Monday(),
-            TuesDay(),
+            TuesCalendarDay(),
             Wednesday(),
             Thursday(),
             Friday(),
@@ -76,7 +76,7 @@ sealed interface Day {
             Sunday(),
         )
 
-        fun getDays(isMondayStarted: Boolean): ImmutableList<Day> {
+        fun getDays(isMondayStarted: Boolean): ImmutableList<CalendarDay> {
             return if (isMondayStarted) monthDayStartedDays else defaultDays
         }
     }

--- a/core/common-ui/src/main/java/team/noweekend/core/common/ui/calendar/model/CalendarImageType.kt
+++ b/core/common-ui/src/main/java/team/noweekend/core/common/ui/calendar/model/CalendarImageType.kt
@@ -1,0 +1,13 @@
+package team.noweekend.core.common.ui.calendar.model
+
+import androidx.annotation.DrawableRes
+import team.noweekend.core.resource.NWKDrawableResource
+
+enum class CalendarImageType(@DrawableRes val id: Int) {
+    NONE(id = NWKDrawableResource.DayTypeNone),
+    FutureSchedule(id = NWKDrawableResource.DayTypeFutureSchedule),
+    BurnOut(id = NWKDrawableResource.DayTypeBurnOut),
+    Rest(id = NWKDrawableResource.DayTypeRest),
+    OverZeroUnderFiftyDegree(id = NWKDrawableResource.DayTypeOverZeroUnderFiftyDegree),
+    OverFiftyUnderSeventyFiveDegree(id = NWKDrawableResource.DayTypeOverFiftyUnderSeventyFiveDegree),
+}

--- a/core/common-ui/src/main/java/team/noweekend/core/common/ui/calendar/model/CalendarMode.kt
+++ b/core/common-ui/src/main/java/team/noweekend/core/common/ui/calendar/model/CalendarMode.kt
@@ -1,0 +1,8 @@
+package team.noweekend.core.common.ui.calendar.model
+
+import androidx.annotation.StringRes
+import team.noweekend.core.resource.NWKStringResource
+
+enum class CalendarMode(@StringRes val id: Int) {
+    WEEK(id = NWKStringResource.Week), MONTH(id = NWKStringResource.Month)
+}

--- a/core/common-ui/src/main/java/team/noweekend/core/common/ui/calendar/model/CalendarState.kt
+++ b/core/common-ui/src/main/java/team/noweekend/core/common/ui/calendar/model/CalendarState.kt
@@ -3,31 +3,32 @@ package team.noweekend.core.common.ui.calendar.model
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.State
-import androidx.compose.runtime.snapshots.SnapshotStateMap
+import kotlinx.collections.immutable.ImmutableMap
 import kotlinx.datetime.LocalDate
-import team.noweekend.core.common.ui.calendar.state.CalendarPagerState.CalendarMode
 
 @Stable
 sealed interface CalendarState {
     val mode: CalendarMode
     val pagerState: PagerState
     val calendarItemClickable: Boolean
-    val pagerData: SnapshotStateMap<Int, WeeksData>
+    val pagerData: ImmutableMap<Int, CalendarWeeksData>
     val selectedDate: State<LocalDate>
 
+    @Stable
     data class Week(
         override val mode: CalendarMode = CalendarMode.WEEK,
         override val pagerState: PagerState,
         override val calendarItemClickable: Boolean = true,
-        override val pagerData: SnapshotStateMap<Int, WeeksData>,
+        override val pagerData: ImmutableMap<Int, CalendarWeeksData>,
         override val selectedDate: State<LocalDate>,
     ) : CalendarState
 
+    @Stable
     data class Month(
         override val mode: CalendarMode = CalendarMode.MONTH,
         override val pagerState: PagerState,
         override val calendarItemClickable: Boolean = true,
-        override val pagerData: SnapshotStateMap<Int, WeeksData>,
+        override val pagerData: ImmutableMap<Int, CalendarWeeksData>,
         override val selectedDate: State<LocalDate>,
     ) : CalendarState
 }

--- a/core/common-ui/src/main/java/team/noweekend/core/common/ui/calendar/model/CalendarState.kt
+++ b/core/common-ui/src/main/java/team/noweekend/core/common/ui/calendar/model/CalendarState.kt
@@ -2,7 +2,6 @@ package team.noweekend.core.common.ui.calendar.model
 
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.runtime.Stable
-import androidx.compose.runtime.State
 import kotlinx.collections.immutable.ImmutableMap
 import kotlinx.datetime.LocalDate
 
@@ -12,7 +11,7 @@ sealed interface CalendarState {
     val pagerState: PagerState
     val calendarItemClickable: Boolean
     val pagerData: ImmutableMap<Int, CalendarWeeksData>
-    val selectedDate: State<LocalDate>
+    val selectedDate: LocalDate
 
     @Stable
     data class Week(
@@ -20,7 +19,7 @@ sealed interface CalendarState {
         override val pagerState: PagerState,
         override val calendarItemClickable: Boolean = true,
         override val pagerData: ImmutableMap<Int, CalendarWeeksData>,
-        override val selectedDate: State<LocalDate>,
+        override val selectedDate: LocalDate,
     ) : CalendarState
 
     @Stable
@@ -29,6 +28,6 @@ sealed interface CalendarState {
         override val pagerState: PagerState,
         override val calendarItemClickable: Boolean = true,
         override val pagerData: ImmutableMap<Int, CalendarWeeksData>,
-        override val selectedDate: State<LocalDate>,
+        override val selectedDate: LocalDate,
     ) : CalendarState
 }

--- a/core/common-ui/src/main/java/team/noweekend/core/common/ui/calendar/model/CalendarWeeksData.kt
+++ b/core/common-ui/src/main/java/team/noweekend/core/common/ui/calendar/model/CalendarWeeksData.kt
@@ -5,22 +5,22 @@ import kotlinx.collections.immutable.persistentListOf
 import kotlinx.datetime.LocalDate
 import team.noweekend.core.common.kotlin.extension.now
 
-data class WeeksData(
+data class CalendarWeeksData(
     val year: Int,
     val month: Int,
     /**
      * 월과 주의 데이터 관리를 위해 2차원 List 로 관리
      */
-    val dateOfWeeks: ImmutableList<ImmutableList<DateOfWeek>>,
+    val calendarDateOfWeeks: ImmutableList<ImmutableList<CalendarDateOfWeek>>,
 ) {
     companion object {
 
         private val now = LocalDate.now()
 
-        val default = WeeksData(
+        val default = CalendarWeeksData(
             year = now.year,
             month = now.monthNumber,
-            dateOfWeeks = persistentListOf(),
+            calendarDateOfWeeks = persistentListOf(),
         )
     }
 }

--- a/core/common-ui/src/main/java/team/noweekend/core/common/ui/calendar/pager/CalendarPager.kt
+++ b/core/common-ui/src/main/java/team/noweekend/core/common/ui/calendar/pager/CalendarPager.kt
@@ -4,11 +4,10 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.VerticalPager
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.State
 import androidx.compose.ui.Modifier
 import team.noweekend.core.common.ui.calendar.component.CalendarItem
-import team.noweekend.core.common.ui.calendar.model.CalendarState
 import team.noweekend.core.common.ui.calendar.model.CalendarDateOfWeek
+import team.noweekend.core.common.ui.calendar.model.CalendarState
 import team.noweekend.core.common.ui.calendar.model.CalendarWeeksData
 
 @Composable

--- a/core/common-ui/src/main/java/team/noweekend/core/common/ui/calendar/pager/CalendarPager.kt
+++ b/core/common-ui/src/main/java/team/noweekend/core/common/ui/calendar/pager/CalendarPager.kt
@@ -4,16 +4,17 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.VerticalPager
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
 import androidx.compose.ui.Modifier
 import team.noweekend.core.common.ui.calendar.component.CalendarItem
 import team.noweekend.core.common.ui.calendar.model.CalendarState
-import team.noweekend.core.common.ui.calendar.model.DateOfWeek
-import team.noweekend.core.common.ui.calendar.model.WeeksData
+import team.noweekend.core.common.ui.calendar.model.CalendarDateOfWeek
+import team.noweekend.core.common.ui.calendar.model.CalendarWeeksData
 
 @Composable
 internal fun CalendarPager(
     calendarState: CalendarState,
-    onClickDateOfWeek: (DateOfWeek) -> Unit,
+    onClickDateOfWeek: (CalendarDateOfWeek) -> Unit,
     modifier: Modifier = Modifier,
     userScrollEnabled: Boolean = true,
 ) {
@@ -25,7 +26,7 @@ internal fun CalendarPager(
                 userScrollEnabled = userScrollEnabled,
             ) { page ->
 
-                val weekDates = calendarState.pagerData[page] ?: WeeksData.default
+                val weekDates = calendarState.pagerData[page] ?: CalendarWeeksData.default
 
                 CalendarItem(
                     dataList = weekDates,
@@ -44,7 +45,7 @@ internal fun CalendarPager(
                 userScrollEnabled = userScrollEnabled,
             ) { page ->
 
-                val monthWeekDates = calendarState.pagerData[page] ?: WeeksData.default
+                val monthWeekDates = calendarState.pagerData[page] ?: CalendarWeeksData.default
 
                 CalendarItem(
                     dataList = monthWeekDates,

--- a/core/common-ui/src/main/java/team/noweekend/core/common/ui/calendar/pager/NWKCalender.kt
+++ b/core/common-ui/src/main/java/team/noweekend/core/common/ui/calendar/pager/NWKCalender.kt
@@ -4,9 +4,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import kotlinx.collections.immutable.toImmutableMap
 import team.noweekend.core.common.ui.calendar.component.DayOfWeekBar
+import team.noweekend.core.common.ui.calendar.model.CalendarDateOfWeek
+import team.noweekend.core.common.ui.calendar.model.CalendarMode
 import team.noweekend.core.common.ui.calendar.model.CalendarState
-import team.noweekend.core.common.ui.calendar.model.DateOfWeek
 import team.noweekend.core.common.ui.calendar.pager.CalendarPager
 import team.noweekend.core.common.ui.calendar.rememberCalendarDataProvider
 import team.noweekend.core.common.ui.calendar.state.rememberCalendarPagerState
@@ -15,7 +17,7 @@ import team.noweekend.core.design.system.foundation.theme.NWKTheme
 @Composable
 fun NWKCalender(
     calendarState: CalendarState,
-    onClickDateOfWeek: (DateOfWeek) -> Unit,
+    onClickDateOfWeek: (CalendarDateOfWeek) -> Unit,
     userScrollEnabled: Boolean,
     modifier: Modifier = Modifier,
 ) {
@@ -44,9 +46,10 @@ private fun PreviewNoneScrollCalendar() {
         }
         NWKCalender(
             calendarState = CalendarState.Week(
-                pagerData = calendarDataProvider.weeksData,
+                pagerData = calendarDataProvider.calendarWeeksData.toImmutableMap(),
                 pagerState = calendarPagerState.weekPagerState,
                 selectedDate = calendarDataProvider.targetDate,
+                mode = CalendarMode.WEEK,
             ),
             onClickDateOfWeek = {
                 println(it.toString())

--- a/core/common-ui/src/main/java/team/noweekend/core/common/ui/calendar/pager/NWKCalender.kt
+++ b/core/common-ui/src/main/java/team/noweekend/core/common/ui/calendar/pager/NWKCalender.kt
@@ -48,7 +48,7 @@ private fun PreviewNoneScrollCalendar() {
             calendarState = CalendarState.Week(
                 pagerData = calendarDataProvider.calendarWeeksData.toImmutableMap(),
                 pagerState = calendarPagerState.weekPagerState,
-                selectedDate = calendarDataProvider.targetDate,
+                selectedDate = calendarDataProvider.targetDate.value,
                 mode = CalendarMode.WEEK,
             ),
             onClickDateOfWeek = {

--- a/core/common-ui/src/main/java/team/noweekend/core/common/ui/calendar/state/CalendarPagerState.kt
+++ b/core/common-ui/src/main/java/team/noweekend/core/common/ui/calendar/state/CalendarPagerState.kt
@@ -1,7 +1,5 @@
 package team.noweekend.core.common.ui.calendar.state
 
-import android.util.Log
-import androidx.annotation.StringRes
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
@@ -12,7 +10,7 @@ import androidx.compose.runtime.snapshots.SnapshotStateList
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
-import team.noweekend.core.resource.NWKStringResource
+import team.noweekend.core.common.ui.calendar.model.CalendarMode
 
 @Composable
 fun rememberCalendarPagerState(
@@ -27,9 +25,6 @@ fun rememberCalendarPagerState(
 class CalendarPagerState(
     private val coroutineScope: CoroutineScope,
 ) {
-    enum class CalendarMode(@StringRes val id: Int) {
-        WEEK(id = NWKStringResource.Week), MONTH(id = NWKStringResource.Month)
-    }
 
     var calendarMode: MutableStateFlow<CalendarMode> = MutableStateFlow(CalendarMode.WEEK)
 
@@ -113,12 +108,10 @@ class CalendarPagerState(
         val direction = detectDirection(localPreviousPage, currentPage)
         when (direction) {
             Direction.Previous -> {
-                log("Moved to previous month")
                 updatePreviousMonthPage(currentPage)
             }
 
             Direction.Next -> {
-                log("Moved to next month.")
                 updateNextMonthPage(currentPage)
             }
 
@@ -134,10 +127,6 @@ class CalendarPagerState(
         }
     }
 
-    fun updateCalendarMode(calendarMode: CalendarMode) {
-        this.calendarMode.value = calendarMode
-    }
-
     enum class Direction {
         Previous, Next, Same
     }
@@ -150,21 +139,5 @@ class CalendarPagerState(
             currentPage < previousPage -> Direction.Previous
             else -> Direction.Same
         }
-    }
-
-    private fun log(message: String, isDebugLevel: Boolean = true) {
-        if (isDebugLevel) {
-            Log.d(TAG, message)
-        } else {
-            Log.e(TAG, message)
-        }
-    }
-
-    fun updateCalendarMode() {
-        calendarMode.value = if (calendarMode.value == CalendarMode.WEEK) CalendarMode.MONTH else CalendarMode.WEEK
-    }
-
-    fun updateCalendarMode(isMonth: Boolean) {
-        calendarMode.value = if (isMonth) CalendarMode.MONTH else CalendarMode.WEEK
     }
 }

--- a/core/common-ui/src/main/java/team/noweekend/core/common/ui/datepicker/WheelDatePicker.kt
+++ b/core/common-ui/src/main/java/team/noweekend/core/common/ui/datepicker/WheelDatePicker.kt
@@ -24,9 +24,9 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.datetime.LocalDate
-import team.noweekend.core.common.ui.calendar.util.CalendarUtils.currentLocalDate
-import team.noweekend.core.common.ui.calendar.util.CalendarUtils.isLeapYear
-import team.noweekend.core.common.ui.calendar.util.CalendarUtils.monthLength
+import team.noweekend.core.common.kotlin.extension.CalendarUtils.currentLocalDate
+import team.noweekend.core.common.kotlin.extension.CalendarUtils.isLeapYear
+import team.noweekend.core.common.kotlin.extension.CalendarUtils.monthLength
 import team.noweekend.core.common.ui.datepicker.core.WheelPicker
 import team.noweekend.core.common.ui.datepicker.model.DatePickerType
 import team.noweekend.core.common.ui.datepicker.preview.PreviewWheelDatePickerParameterProvider

--- a/core/common-ui/src/main/java/team/noweekend/core/common/ui/datepicker/WheelTimePicker.kt
+++ b/core/common-ui/src/main/java/team/noweekend/core/common/ui/datepicker/WheelTimePicker.kt
@@ -25,7 +25,7 @@ import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.datetime.LocalTime
-import team.noweekend.core.common.ui.calendar.util.CalendarUtils.currentLocalDateTime
+import team.noweekend.core.common.kotlin.extension.CalendarUtils.currentLocalDateTime
 import team.noweekend.core.common.ui.datepicker.core.LocalTimeUtil.convertToLocalTime
 import team.noweekend.core.common.ui.datepicker.core.WheelPicker
 import team.noweekend.core.common.ui.datepicker.model.Meridiem

--- a/core/data/src/main/java/team/noweekend/data/di/RepositoryModule.kt
+++ b/core/data/src/main/java/team/noweekend/data/di/RepositoryModule.kt
@@ -6,8 +6,10 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import team.noweekend.core.domain.repository.AuthRepository
 import team.noweekend.core.domain.repository.SampleRepository
+import team.noweekend.core.domain.repository.ScheduleRepository
 import team.noweekend.data.repository.AuthRepositoryImpl
 import team.noweekend.data.repository.SampleRepositoryImpl
+import team.noweekend.data.repository.ScheduleRepositoryImpl
 import javax.inject.Singleton
 
 @Module
@@ -21,4 +23,8 @@ internal interface RepositoryModule {
     @Singleton
     @Binds
     fun bindAuthRepository(authRepositoryImpl: AuthRepositoryImpl): AuthRepository
+
+    @Singleton
+    @Binds
+    fun bindScheduleRepository(scheduleRepositoryImpl: ScheduleRepositoryImpl): ScheduleRepository
 }

--- a/core/data/src/main/java/team/noweekend/data/model/ScheduleMapper.kt
+++ b/core/data/src/main/java/team/noweekend/data/model/ScheduleMapper.kt
@@ -1,0 +1,28 @@
+package team.noweekend.data.model
+
+import team.noweekend.core.model.alarm.AlarmOption
+import team.noweekend.core.model.schedule.DateWithSchedules
+import team.noweekend.core.model.schedule.Schedule
+import team.noweekend.core.model.schedule.ScheduleCategory
+import team.noweekend.core.remote.model.schedule.response.GetScheduleResponse
+
+fun GetScheduleResponse.toDomain() : DateWithSchedules {
+    return DateWithSchedules(
+        date = this.date,
+        dailyTemperature =  this.dailyTemperature,
+        schedules = this.schedules.map{ scheduleModel->
+            Schedule(
+                id = scheduleModel.id,
+                title = scheduleModel.title,
+                startTime = scheduleModel.startTime,
+                endTime = scheduleModel.endTime,
+                category = ScheduleCategory.valueOf(scheduleModel.category),
+                temperature = scheduleModel.temperature,
+                allDay = scheduleModel.allDay,
+                completed = scheduleModel.completed,
+                alarmOption = AlarmOption.valueOf(scheduleModel.alarmOption)
+            )
+        }
+    )
+
+}

--- a/core/data/src/main/java/team/noweekend/data/model/ScheduleMapper.kt
+++ b/core/data/src/main/java/team/noweekend/data/model/ScheduleMapper.kt
@@ -6,11 +6,11 @@ import team.noweekend.core.model.schedule.Schedule
 import team.noweekend.core.model.schedule.ScheduleCategory
 import team.noweekend.core.remote.model.schedule.response.GetScheduleResponse
 
-fun GetScheduleResponse.toDomain() : DateWithSchedules {
+fun GetScheduleResponse.toDomain(): DateWithSchedules {
     return DateWithSchedules(
         date = this.date,
-        dailyTemperature =  this.dailyTemperature,
-        schedules = this.schedules.map{ scheduleModel->
+        dailyTemperature = this.dailyTemperature,
+        schedules = this.schedules.map { scheduleModel ->
             Schedule(
                 id = scheduleModel.id,
                 title = scheduleModel.title,
@@ -20,9 +20,8 @@ fun GetScheduleResponse.toDomain() : DateWithSchedules {
                 temperature = scheduleModel.temperature,
                 allDay = scheduleModel.allDay,
                 completed = scheduleModel.completed,
-                alarmOption = AlarmOption.valueOf(scheduleModel.alarmOption)
+                alarmOption = AlarmOption.valueOf(scheduleModel.alarmOption),
             )
-        }
+        },
     )
-
 }

--- a/core/data/src/main/java/team/noweekend/data/repository/ScheduleRepositoryImpl.kt
+++ b/core/data/src/main/java/team/noweekend/data/repository/ScheduleRepositoryImpl.kt
@@ -1,0 +1,19 @@
+package team.noweekend.data.repository
+
+import team.noweekend.core.domain.repository.ScheduleRepository
+import team.noweekend.core.model.schedule.DateWithSchedules
+import team.noweekend.core.remote.api.schedule.ScheduleApi
+import team.noweekend.data.model.toDomain
+import javax.inject.Inject
+
+class ScheduleRepositoryImpl @Inject constructor(
+    private val scheduleApi: ScheduleApi,
+) : ScheduleRepository {
+
+    override suspend fun getSchedule(startDate: String, endDate: String): List<DateWithSchedules> {
+        return scheduleApi.getSchedule(
+            startDate = startDate,
+            endDate = endDate,
+        ).map { response -> response.toDomain() }
+    }
+}

--- a/core/domain/build.gradle.kts
+++ b/core/domain/build.gradle.kts
@@ -8,4 +8,5 @@ dependencies {
 
     implementation(libs.kotlinx.coroutine.core)
     implementation(libs.javax.inject)
+    implementation(libs.kotlinx.datetime)
 }

--- a/core/domain/src/main/java/team/noweekend/core/domain/repository/ScheduleRepository.kt
+++ b/core/domain/src/main/java/team/noweekend/core/domain/repository/ScheduleRepository.kt
@@ -1,0 +1,10 @@
+package team.noweekend.core.domain.repository
+
+import team.noweekend.core.model.schedule.DateWithSchedules
+
+interface ScheduleRepository {
+    suspend fun getSchedule(
+        startDate: String,
+        endDate: String,
+    ): List<DateWithSchedules>
+}

--- a/core/domain/src/main/java/team/noweekend/core/domain/usecase/CalendarDataProviderUseCase.kt
+++ b/core/domain/src/main/java/team/noweekend/core/domain/usecase/CalendarDataProviderUseCase.kt
@@ -48,13 +48,11 @@ class CalendarDataProviderUseCase @Inject constructor(
     val monthData: StateFlow<Map<Int, WeeksData>> = _monthData.asStateFlow()
 
     private suspend fun getWeekDates(startedMonday: LocalDate, month: Int = startedMonday.monthNumber): WeeksData {
-
         val startDate = startedMonday.toFormattedString(LocalDate.YEAR_MONTH_DAY_PATTERN)
         val endDate = startedMonday.plusDays(6).toFormattedString(LocalDate.YEAR_MONTH_DAY_PATTERN)
 
         val scheduleList = scheduleRepository.getSchedule(startDate = startDate, endDate = endDate)
         val currentDate = LocalDate.now()
-
 
         return WeeksData(
             year = startedMonday.year,
@@ -78,7 +76,6 @@ class CalendarDataProviderUseCase @Inject constructor(
         )
     }
 
-
     private suspend fun getWeekDates(startedMonday: LocalDate): WeeksData {
         return getWeekDates(startedMonday = startedMonday, month = startedMonday.monthNumber)
     }
@@ -87,7 +84,6 @@ class CalendarDataProviderUseCase @Inject constructor(
         val currentDay: LocalDate = LocalDate.now()
         _targetDate.update { currentDay }
         val targetWeekMonday: LocalDate = currentDay.previousOrSame(DayOfWeek.MONDAY)
-
 
         val newMap = mapOf(
             initPage - 1 to getWeekDates(targetWeekMonday.minusWeeks(1)),
@@ -141,7 +137,6 @@ class CalendarDataProviderUseCase @Inject constructor(
         }
     }
 
-
     /**
      * 월 캘린더 데이터 초기화
      */
@@ -159,7 +154,6 @@ class CalendarDataProviderUseCase @Inject constructor(
         )
     }
 
-
     /**
      * 현재 페이지 의 이전 페이지 월 데이터 update
      */
@@ -174,9 +168,7 @@ class CalendarDataProviderUseCase @Inject constructor(
 
         copiedMap.remove(removeNeededPage)
         _monthData.update { copiedMap }
-
     }
-
 
     /**
      * 현재 페이지 의 다음 페이지 월 데이터 update
@@ -197,7 +189,6 @@ class CalendarDataProviderUseCase @Inject constructor(
             copiedMap
         }
     }
-
 
     /**
      * 월의 첫 날이 포함된 주의 월요일부터 마지막 날이 포함된 주의 일요일까지 날짜 리스트 반환
@@ -230,7 +221,6 @@ class CalendarDataProviderUseCase @Inject constructor(
             localDate.plus(1, DateTimeUnit.DAY)
         }.takeWhile { it <= lastSundayOfWeekContainingLastDay }
             .count()
-
 
         val startDate = firstMondayOfWeekContainingFirstDay.toFormattedString(LocalDate.YEAR_MONTH_DAY_PATTERN)
         val endDate = firstMondayOfWeekContainingFirstDay.plusDays(daysInPeriod - 1)
@@ -285,7 +275,6 @@ class CalendarDataProviderUseCase @Inject constructor(
 
     fun getWeeksData(page: Int): WeeksData? = _weeksData.value[page]
     fun getMonthData(page: Int): WeeksData? = _monthData.value[page]
-
 
     sealed interface CalendarDataProviderEvent {
         data object CompleteInitWeeksCalendar : CalendarDataProviderEvent

--- a/core/domain/src/main/java/team/noweekend/core/domain/usecase/CalendarDataProviderUseCase.kt
+++ b/core/domain/src/main/java/team/noweekend/core/domain/usecase/CalendarDataProviderUseCase.kt
@@ -1,0 +1,294 @@
+package team.noweekend.core.domain.usecase
+
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.DayOfWeek
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.plus
+import team.noweekend.core.common.kotlin.extension.CalendarUtils.firstDayOfMonth
+import team.noweekend.core.common.kotlin.extension.CalendarUtils.lastDayOfMonth
+import team.noweekend.core.common.kotlin.extension.CalendarUtils.minusMonths
+import team.noweekend.core.common.kotlin.extension.CalendarUtils.minusWeeks
+import team.noweekend.core.common.kotlin.extension.CalendarUtils.nextOrSame
+import team.noweekend.core.common.kotlin.extension.CalendarUtils.plusDays
+import team.noweekend.core.common.kotlin.extension.CalendarUtils.plusMonths
+import team.noweekend.core.common.kotlin.extension.CalendarUtils.plusWeeks
+import team.noweekend.core.common.kotlin.extension.CalendarUtils.previousOrSame
+import team.noweekend.core.common.kotlin.extension.YEAR_MONTH_DAY_PATTERN
+import team.noweekend.core.common.kotlin.extension.now
+import team.noweekend.core.common.kotlin.extension.parseLocalDateString
+import team.noweekend.core.common.kotlin.extension.toFormattedString
+import team.noweekend.core.domain.repository.ScheduleRepository
+import team.noweekend.core.model.calendar.DateOfWeek
+import team.noweekend.core.model.calendar.WeeksData
+import team.noweekend.core.model.calendar.getImageType
+import team.noweekend.core.model.schedule.ScheduleCategory
+import javax.inject.Inject
+
+class CalendarDataProviderUseCase @Inject constructor(
+    private val scheduleRepository: ScheduleRepository,
+) {
+    private var _targetDate: MutableStateFlow<LocalDate> = MutableStateFlow(LocalDate.now())
+    val targetDate: StateFlow<LocalDate> = _targetDate.asStateFlow()
+
+    private val _calendarDataProviderEventChannel: Channel<CalendarDataProviderEvent> =
+        Channel(capacity = Channel.BUFFERED)
+    val calendarDataProviderEventFlow: Flow<CalendarDataProviderEvent> =
+        _calendarDataProviderEventChannel.receiveAsFlow()
+
+    private val _weeksData: MutableStateFlow<Map<Int, WeeksData>> = MutableStateFlow(mapOf())
+    val weeksDate: StateFlow<Map<Int, WeeksData>> = _weeksData.asStateFlow()
+    private val _monthData: MutableStateFlow<Map<Int, WeeksData>> = MutableStateFlow(mapOf())
+    val monthData: StateFlow<Map<Int, WeeksData>> = _monthData.asStateFlow()
+
+    private suspend fun getWeekDates(startedMonday: LocalDate, month: Int = startedMonday.monthNumber): WeeksData {
+
+        val startDate = startedMonday.toFormattedString(LocalDate.YEAR_MONTH_DAY_PATTERN)
+        val endDate = startedMonday.plusDays(6).toFormattedString(LocalDate.YEAR_MONTH_DAY_PATTERN)
+
+        val scheduleList = scheduleRepository.getSchedule(startDate = startDate, endDate = endDate)
+        val currentDate = LocalDate.now()
+
+
+        return WeeksData(
+            year = startedMonday.year,
+            month = month,
+            dateOfWeeks = scheduleList.map { dateWithSchedules ->
+                val parsingDate = LocalDate.parseLocalDateString(isoString = dateWithSchedules.date)
+                val isFuture = parsingDate > currentDate
+                val hasRest =
+                    dateWithSchedules.schedules.any { schedule -> schedule.category == ScheduleCategory.LEAVE }
+                val dateOfWeek = DateOfWeek(
+                    localDate = parsingDate,
+                    isCurrentDate = parsingDate == currentDate,
+                    imageType = getImageType(
+                        temperature = dateWithSchedules.dailyTemperature,
+                        isFuture = isFuture,
+                        hasRest = hasRest,
+                    ),
+                )
+                dateOfWeek
+            }.chunked(7),
+        )
+    }
+
+
+    private suspend fun getWeekDates(startedMonday: LocalDate): WeeksData {
+        return getWeekDates(startedMonday = startedMonday, month = startedMonday.monthNumber)
+    }
+
+    suspend fun initWeekCalendar(initPage: Int) {
+        val currentDay: LocalDate = LocalDate.now()
+        _targetDate.update { currentDay }
+        val targetWeekMonday: LocalDate = currentDay.previousOrSame(DayOfWeek.MONDAY)
+
+
+        val newMap = mapOf(
+            initPage - 1 to getWeekDates(targetWeekMonday.minusWeeks(1)),
+            initPage to getWeekDates(targetWeekMonday),
+            initPage + 1 to getWeekDates(targetWeekMonday.plusWeeks(1)),
+        )
+        _weeksData.update {
+            newMap.toMutableMap()
+        }
+
+        _calendarDataProviderEventChannel.send(
+            element = CalendarDataProviderEvent.CompleteInitWeeksCalendar,
+        )
+    }
+
+    suspend fun updatePreviousWeeksData(currentPage: Int) {
+        val offsetPageData =
+            _weeksData.value[currentPage] ?: throw IllegalStateException("offsetPageData $currentPage is null")
+        val currentWeekMonday: DateOfWeek = offsetPageData.dateOfWeeks.flatten().first()
+
+        val prevPage = currentPage - 1
+
+        val copiedMap = _weeksData.value.toMutableMap()
+        copiedMap[prevPage] = getWeekDates(startedMonday = currentWeekMonday.localDate.minusWeeks(1))
+        val removeNeededPage = currentPage + 2
+        copiedMap.remove(removeNeededPage)
+
+        _weeksData.update {
+            copiedMap
+        }
+    }
+
+    /**
+     * 현재 페이지 의 다음 페이지 주 데이터 update
+     */
+    suspend fun updateNextWeeksData(currentPage: Int) {
+        val offsetPageData = _weeksData.value[currentPage] ?: throw IllegalStateException("offsetPageData is null")
+        val currentWeekMonday: DateOfWeek = offsetPageData.dateOfWeeks.flatten().first()
+
+        val nextPageOffset = currentPage + 1
+
+        val copiedMap = _weeksData.value.toMutableMap()
+
+        copiedMap[nextPageOffset] = getWeekDates(startedMonday = currentWeekMonday.localDate.plusWeeks(1))
+
+        val removeNeededPage = currentPage - 2
+        copiedMap.remove(removeNeededPage)
+
+        _weeksData.update {
+            copiedMap
+        }
+    }
+
+
+    /**
+     * 월 캘린더 데이터 초기화
+     */
+    suspend fun initMonthCalendar(page: Int, chooserMonth: LocalDate) {
+        val newMap = mapOf(
+            page to getMonthDates(monthStart = chooserMonth),
+            page - 1 to getMonthDates(monthStart = chooserMonth.minusMonths(1)),
+            page + 1 to getMonthDates(monthStart = chooserMonth.plusMonths(1)),
+        )
+
+        _monthData.update { newMap }
+
+        _calendarDataProviderEventChannel.send(
+            element = CalendarDataProviderEvent.CompleteInitMonthCalendar,
+        )
+    }
+
+
+    /**
+     * 현재 페이지 의 이전 페이지 월 데이터 update
+     */
+    suspend fun updatePreviousMonthData(currentPage: Int) {
+        val currentMonthLocalDate: LocalDate = getCurrentMonthLocalDate(currentPage = currentPage)
+        val prevPage = currentPage - 1
+
+        val copiedMap = _monthData.value.toMutableMap()
+        copiedMap[prevPage] = getMonthDates(monthStart = currentMonthLocalDate.minusMonths(1))
+
+        val removeNeededPage = currentPage + 2
+
+        copiedMap.remove(removeNeededPage)
+        _monthData.update { copiedMap }
+
+    }
+
+
+    /**
+     * 현재 페이지 의 다음 페이지 월 데이터 update
+     */
+    suspend fun updateNextMonthData(currentPage: Int) {
+        val currentMonthLocalDate: LocalDate = getCurrentMonthLocalDate(currentPage = currentPage)
+        val nextPage = currentPage + 1
+
+        val copiedMap = _monthData.value.toMutableMap()
+
+        copiedMap[nextPage] = getMonthDates(monthStart = currentMonthLocalDate.plusMonths(1))
+
+        val removeNeededPage = currentPage - 2
+
+        copiedMap.remove(removeNeededPage)
+
+        _monthData.update {
+            copiedMap
+        }
+    }
+
+
+    /**
+     * 월의 첫 날이 포함된 주의 월요일부터 마지막 날이 포함된 주의 일요일까지 날짜 리스트 반환
+     */
+    private suspend fun getMonthDates(monthStart: LocalDate): WeeksData {
+        /**
+         * 주어진 월의 첫 날
+         */
+        val firstDayOfMonth: LocalDate = monthStart.firstDayOfMonth()
+
+        /**
+         * 주어진 월의 첫 날이 포함된 주의 월요일
+         */
+        val firstMondayOfWeekContainingFirstDay: LocalDate = firstDayOfMonth.previousOrSame(DayOfWeek.MONDAY)
+
+        /**
+         * 주어진 월의 마지막 날
+         */
+        val monthEnd: LocalDate = monthStart.lastDayOfMonth()
+
+        /**
+         * 주어진 월의 마지막 날이 포함된 주의 일요일
+         */
+        val lastSundayOfWeekContainingLastDay: LocalDate = monthEnd.nextOrSame(DayOfWeek.SUNDAY)
+
+        /**
+         * 주어진 월의 첫 날이 포함된 주의 월요일 부터 마지막 날이 포함된 주의 일요일 까지의 일 수
+         */
+        val daysInPeriod: Int = generateSequence(firstMondayOfWeekContainingFirstDay) { localDate ->
+            localDate.plus(1, DateTimeUnit.DAY)
+        }.takeWhile { it <= lastSundayOfWeekContainingLastDay }
+            .count()
+
+
+        val startDate = firstMondayOfWeekContainingFirstDay.toFormattedString(LocalDate.YEAR_MONTH_DAY_PATTERN)
+        val endDate = firstMondayOfWeekContainingFirstDay.plusDays(daysInPeriod - 1)
+            .toFormattedString(LocalDate.YEAR_MONTH_DAY_PATTERN)
+
+        val scheduleList = scheduleRepository.getSchedule(startDate = startDate, endDate = endDate)
+        val currentDate = LocalDate.now()
+
+        return WeeksData(
+            year = monthStart.year,
+            month = monthStart.monthNumber,
+            dateOfWeeks = scheduleList.map { dateWithSchedules ->
+                val parsingDate = LocalDate.parseLocalDateString(isoString = dateWithSchedules.date)
+                val isFuture = parsingDate > currentDate
+                val hasRest =
+                    dateWithSchedules.schedules.any { schedule -> schedule.category == ScheduleCategory.LEAVE }
+
+                DateOfWeek(
+                    localDate = parsingDate,
+                    isCurrentDate = parsingDate == currentDate,
+                    imageType = getImageType(
+                        temperature = dateWithSchedules.dailyTemperature,
+                        isFuture = isFuture,
+                        hasRest = hasRest,
+                    ),
+                )
+            }.chunked(7),
+        )
+    }
+
+    /**
+     * [currentPage] pagerState의 currentPage
+     * 월의 시작이 다른 달일 수도 있어 정확한 현재 달의 LocalDate 값을 반환.
+     */
+    private fun getCurrentMonthLocalDate(currentPage: Int): LocalDate {
+        val currentMonthData: WeeksData =
+            _monthData.value[currentPage] ?: throw IllegalStateException("currentPage is null")
+        val currentMonth: Int = currentMonthData.month
+        val currentMonthLocalDateOfWeek: DateOfWeek =
+            currentMonthData.dateOfWeeks.flatten().first { dateOfWeek: DateOfWeek ->
+                dateOfWeek.localDate.monthNumber == currentMonth
+            }
+        return currentMonthLocalDateOfWeek.localDate
+    }
+
+    /**
+     * 현재 선택된 날짜를 update.
+     */
+    fun updateTargetDate(dateOfWeek: DateOfWeek) {
+        _targetDate.value = dateOfWeek.localDate
+    }
+
+    fun getWeeksData(page: Int): WeeksData? = _weeksData.value[page]
+    fun getMonthData(page: Int): WeeksData? = _monthData.value[page]
+
+
+    sealed interface CalendarDataProviderEvent {
+        data object CompleteInitWeeksCalendar : CalendarDataProviderEvent
+        data object CompleteInitMonthCalendar : CalendarDataProviderEvent
+    }
+}

--- a/core/model/build.gradle.kts
+++ b/core/model/build.gradle.kts
@@ -2,3 +2,7 @@ plugins {
     id("kotlin")
     alias(libs.plugins.team.noweekend.jvm.library)
 }
+
+dependencies{
+    implementation(libs.kotlinx.datetime)
+}

--- a/core/model/build.gradle.kts
+++ b/core/model/build.gradle.kts
@@ -3,6 +3,6 @@ plugins {
     alias(libs.plugins.team.noweekend.jvm.library)
 }
 
-dependencies{
+dependencies {
     implementation(libs.kotlinx.datetime)
 }

--- a/core/model/src/main/java/team/noweekend/core/model/calendar/DateOfWeek.kt
+++ b/core/model/src/main/java/team/noweekend/core/model/calendar/DateOfWeek.kt
@@ -1,0 +1,9 @@
+package team.noweekend.core.model.calendar
+
+import kotlinx.datetime.LocalDate
+
+data class DateOfWeek(
+    val imageType: ImageType,
+    val localDate: LocalDate,
+    val isCurrentDate: Boolean,
+)

--- a/core/model/src/main/java/team/noweekend/core/model/calendar/ImageType.kt
+++ b/core/model/src/main/java/team/noweekend/core/model/calendar/ImageType.kt
@@ -6,12 +6,13 @@ enum class ImageType {
     BURN_OUT,
     REST,
     OVER_ZERO_UNDER_FIFTY_DEGREE,
-    OVER_FIFTY_UNDER_SEVENTY_FIVE_DEGREE
+    OVER_FIFTY_UNDER_SEVENTY_FIVE_DEGREE,
+
     ;
 }
 
-fun getImageType(temperature: Int, isFuture: Boolean, hasRest: Boolean) : ImageType{
-    return when{
+fun getImageType(temperature: Int, isFuture: Boolean, hasRest: Boolean): ImageType {
+    return when {
         hasRest -> ImageType.REST
         isFuture -> ImageType.FUTURE_SCHEDULE
         temperature in 1..49 -> ImageType.OVER_ZERO_UNDER_FIFTY_DEGREE
@@ -19,5 +20,4 @@ fun getImageType(temperature: Int, isFuture: Boolean, hasRest: Boolean) : ImageT
         temperature >= 75 -> ImageType.BURN_OUT
         else -> ImageType.NONE
     }
-
 }

--- a/core/model/src/main/java/team/noweekend/core/model/calendar/ImageType.kt
+++ b/core/model/src/main/java/team/noweekend/core/model/calendar/ImageType.kt
@@ -1,0 +1,23 @@
+package team.noweekend.core.model.calendar
+
+enum class ImageType {
+    NONE,
+    FUTURE_SCHEDULE,
+    BURN_OUT,
+    REST,
+    OVER_ZERO_UNDER_FIFTY_DEGREE,
+    OVER_FIFTY_UNDER_SEVENTY_FIVE_DEGREE
+    ;
+}
+
+fun getImageType(temperature: Int, isFuture: Boolean, hasRest: Boolean) : ImageType{
+    return when{
+        hasRest -> ImageType.REST
+        isFuture -> ImageType.FUTURE_SCHEDULE
+        temperature in 1..49 -> ImageType.OVER_ZERO_UNDER_FIFTY_DEGREE
+        temperature in 50..74 -> ImageType.OVER_FIFTY_UNDER_SEVENTY_FIVE_DEGREE
+        temperature >= 75 -> ImageType.BURN_OUT
+        else -> ImageType.NONE
+    }
+
+}

--- a/core/model/src/main/java/team/noweekend/core/model/calendar/WeeksData.kt
+++ b/core/model/src/main/java/team/noweekend/core/model/calendar/WeeksData.kt
@@ -1,7 +1,5 @@
 package team.noweekend.core.model.calendar
 
-import kotlinx.datetime.LocalDate
-
 data class WeeksData(
     val year: Int,
     val month: Int,
@@ -21,4 +19,3 @@ data class WeeksData(
 //        )
 //    }
 }
-

--- a/core/model/src/main/java/team/noweekend/core/model/calendar/WeeksData.kt
+++ b/core/model/src/main/java/team/noweekend/core/model/calendar/WeeksData.kt
@@ -1,0 +1,24 @@
+package team.noweekend.core.model.calendar
+
+import kotlinx.datetime.LocalDate
+
+data class WeeksData(
+    val year: Int,
+    val month: Int,
+    /**
+     * 월과 주의 데이터 관리를 위해 2차원 List 로 관리
+     */
+    val dateOfWeeks: List<List<DateOfWeek>>,
+) {
+//    companion object {
+//
+//        private val now = LocalDate.now()
+//
+//        val default = WeeksData(
+//            year = now.year,
+//            month = now.monthNumber,
+//            dateOfWeeks = persistentListOf(),
+//        )
+//    }
+}
+

--- a/core/model/src/main/java/team/noweekend/core/model/schedule/DateWithSchedules.kt
+++ b/core/model/src/main/java/team/noweekend/core/model/schedule/DateWithSchedules.kt
@@ -1,0 +1,16 @@
+package team.noweekend.core.model.schedule
+
+data class DateWithSchedules(
+    /**
+     * 날짜 YYYY-MM-DD
+     */
+    val date: String,
+    /**
+     * 해당 날짜 온도
+     */
+    val dailyTemperature: Int,
+    /**
+     * 해당 날짜에 있는 스케줄 정보
+     */
+    val schedules: List<Schedule>
+)

--- a/core/model/src/main/java/team/noweekend/core/model/schedule/DateWithSchedules.kt
+++ b/core/model/src/main/java/team/noweekend/core/model/schedule/DateWithSchedules.kt
@@ -12,5 +12,5 @@ data class DateWithSchedules(
     /**
      * 해당 날짜에 있는 스케줄 정보
      */
-    val schedules: List<Schedule>
+    val schedules: List<Schedule>,
 )

--- a/core/remote/src/main/kotlin/team/noweekend/core/remote/api/schedule/ScheduleApi.kt
+++ b/core/remote/src/main/kotlin/team/noweekend/core/remote/api/schedule/ScheduleApi.kt
@@ -26,7 +26,6 @@ interface ScheduleApi {
 
     companion object {
         const val SCHEDULE_PATH: String = "/api/v1/schedule"
-        const val SCHEDULE_PATH_WITH_ID: String = "/api/v1/schedule/{id}"
         const val START_DATE: String = "start_date"
         const val END_DATE: String = "end_date"
     }

--- a/core/remote/src/main/kotlin/team/noweekend/core/remote/api/schedule/ScheduleApi.kt
+++ b/core/remote/src/main/kotlin/team/noweekend/core/remote/api/schedule/ScheduleApi.kt
@@ -1,0 +1,33 @@
+package team.noweekend.core.remote.api.schedule
+
+import team.noweekend.core.remote.model.schedule.common.ScheduleModel
+import team.noweekend.core.remote.model.schedule.response.DeleteScheduleResponse
+import team.noweekend.core.remote.model.schedule.response.EditScheduleRequest
+import team.noweekend.core.remote.model.schedule.response.GetScheduleResponse
+
+interface ScheduleApi {
+    suspend fun getSchedule(
+        startDate: String,
+        endDate: String
+    ): List<GetScheduleResponse>
+
+    suspend fun editSchedule(
+        id: String,
+        editScheduleRequest: EditScheduleRequest
+    ): ScheduleModel
+
+    suspend fun deleteSchedule(
+        id: String
+    ): DeleteScheduleResponse
+
+    suspend fun createSchedule(
+        createScheduleRequest: ScheduleModel
+    ): ScheduleModel
+
+    companion object {
+        const val SCHEDULE_PATH: String = "/api/v1/schedule"
+        const val SCHEDULE_PATH_WITH_ID: String = "/api/v1/schedule/{id}"
+        const val START_DATE: String = "start_date"
+        const val END_DATE: String = "end_date"
+    }
+}

--- a/core/remote/src/main/kotlin/team/noweekend/core/remote/api/schedule/ScheduleApiImpl.kt
+++ b/core/remote/src/main/kotlin/team/noweekend/core/remote/api/schedule/ScheduleApiImpl.kt
@@ -1,0 +1,52 @@
+package team.noweekend.core.remote.api.schedule
+
+import io.ktor.client.HttpClient
+import team.noweekend.core.remote.api.schedule.ScheduleApi.Companion.END_DATE
+import team.noweekend.core.remote.api.schedule.ScheduleApi.Companion.START_DATE
+import team.noweekend.core.remote.base.deleteApiCall
+import team.noweekend.core.remote.base.getApiCall
+import team.noweekend.core.remote.base.postApiCall
+import team.noweekend.core.remote.base.putApiCall
+import team.noweekend.core.remote.model.schedule.common.ScheduleModel
+import team.noweekend.core.remote.model.schedule.response.DeleteScheduleResponse
+import team.noweekend.core.remote.model.schedule.response.EditScheduleRequest
+import team.noweekend.core.remote.model.schedule.response.GetScheduleResponse
+import team.noweekend.core.remote.qulifier.BasicClient
+import javax.inject.Inject
+
+class ScheduleApiImpl @Inject constructor(
+    @BasicClient val client: HttpClient,
+) : ScheduleApi {
+    override suspend fun getSchedule(startDate: String, endDate: String): List<GetScheduleResponse> {
+        return client.getApiCall(
+            path = ScheduleApi.SCHEDULE_PATH,
+            queries = mapOf(
+                START_DATE to startDate,
+                END_DATE to endDate,
+            ),
+        )
+    }
+
+    override suspend fun editSchedule(
+        id: String,
+        editScheduleRequest: EditScheduleRequest,
+    ): ScheduleModel {
+        return client.putApiCall(
+            path = ScheduleApi.SCHEDULE_PATH_WITH_ID,
+            body = editScheduleRequest,
+        )
+    }
+
+    override suspend fun deleteSchedule(id: String): DeleteScheduleResponse {
+        return client.deleteApiCall(
+            path = ScheduleApi.SCHEDULE_PATH_WITH_ID,
+        )
+    }
+
+    override suspend fun createSchedule(createScheduleRequest: ScheduleModel): ScheduleModel {
+        return client.postApiCall(
+            path = ScheduleApi.SCHEDULE_PATH,
+            body = createScheduleRequest
+        )
+    }
+}

--- a/core/remote/src/main/kotlin/team/noweekend/core/remote/api/schedule/ScheduleApiImpl.kt
+++ b/core/remote/src/main/kotlin/team/noweekend/core/remote/api/schedule/ScheduleApiImpl.kt
@@ -32,21 +32,21 @@ class ScheduleApiImpl @Inject constructor(
         editScheduleRequest: EditScheduleRequest,
     ): ScheduleModel {
         return client.putApiCall(
-            path = ScheduleApi.SCHEDULE_PATH_WITH_ID,
+            path = ScheduleApi.SCHEDULE_PATH + "/${id}",
             body = editScheduleRequest,
         )
     }
 
     override suspend fun deleteSchedule(id: String): DeleteScheduleResponse {
         return client.deleteApiCall(
-            path = ScheduleApi.SCHEDULE_PATH_WITH_ID,
+            path = ScheduleApi.SCHEDULE_PATH + "/${id}",
         )
     }
 
     override suspend fun createSchedule(createScheduleRequest: ScheduleModel): ScheduleModel {
         return client.postApiCall(
             path = ScheduleApi.SCHEDULE_PATH,
-            body = createScheduleRequest
+            body = createScheduleRequest,
         )
     }
 }

--- a/core/remote/src/main/kotlin/team/noweekend/core/remote/di/NetworkApiModule.kt
+++ b/core/remote/src/main/kotlin/team/noweekend/core/remote/di/NetworkApiModule.kt
@@ -6,6 +6,8 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import team.noweekend.core.remote.api.SampleApi
 import team.noweekend.core.remote.api.SampleApiImpl
+import team.noweekend.core.remote.api.schedule.ScheduleApi
+import team.noweekend.core.remote.api.schedule.ScheduleApiImpl
 import javax.inject.Singleton
 
 @Module
@@ -14,4 +16,8 @@ internal interface NetworkApiModule {
     @Binds
     @Singleton
     fun bindSampleApi(sampleApiImpl: SampleApiImpl): SampleApi
+
+    @Binds
+    @Singleton
+    fun bindScheduleApi(scheduleApiImpl: ScheduleApiImpl) : ScheduleApi
 }

--- a/core/remote/src/main/kotlin/team/noweekend/core/remote/model/schedule/common/ScheduleModel.kt
+++ b/core/remote/src/main/kotlin/team/noweekend/core/remote/model/schedule/common/ScheduleModel.kt
@@ -1,0 +1,16 @@
+package team.noweekend.core.remote.model.schedule.common
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ScheduleModel(
+    val id: String,
+    val title: String,
+    val startTime: String,
+    val endTime: String,
+    val category: String,
+    val temperature: Int,
+    val allDay: Boolean,
+    val alarmOption: String,
+    val completed: Boolean,
+)

--- a/core/remote/src/main/kotlin/team/noweekend/core/remote/model/schedule/common/TimeModel.kt
+++ b/core/remote/src/main/kotlin/team/noweekend/core/remote/model/schedule/common/TimeModel.kt
@@ -1,0 +1,8 @@
+package team.noweekend.core.remote.model.schedule.common
+
+data class TimeModel(
+    val hour: Int,
+    val minute: Int,
+    val second: Int,
+    val nano: Int
+)

--- a/core/remote/src/main/kotlin/team/noweekend/core/remote/model/schedule/response/DeleteScheduleResponse.kt
+++ b/core/remote/src/main/kotlin/team/noweekend/core/remote/model/schedule/response/DeleteScheduleResponse.kt
@@ -1,0 +1,6 @@
+package team.noweekend.core.remote.model.schedule.response
+
+@JvmInline
+value class DeleteScheduleResponse(
+    val data: String,
+)

--- a/core/remote/src/main/kotlin/team/noweekend/core/remote/model/schedule/response/EditScheduleRequest.kt
+++ b/core/remote/src/main/kotlin/team/noweekend/core/remote/model/schedule/response/EditScheduleRequest.kt
@@ -1,0 +1,14 @@
+package team.noweekend.core.remote.model.schedule.response
+
+import team.noweekend.core.remote.model.schedule.common.TimeModel
+
+data class EditScheduleRequest(
+    val title: String,
+    val startTime: TimeModel,
+    val endTime: TimeModel,
+    val category: String,
+    val temperature: Int,
+    val allDay: Boolean,
+    val alarmOption: String,
+)
+

--- a/core/remote/src/main/kotlin/team/noweekend/core/remote/model/schedule/response/GetScheduleResponse.kt
+++ b/core/remote/src/main/kotlin/team/noweekend/core/remote/model/schedule/response/GetScheduleResponse.kt
@@ -1,0 +1,11 @@
+package team.noweekend.core.remote.model.schedule.response
+
+import kotlinx.serialization.Serializable
+import team.noweekend.core.remote.model.schedule.common.ScheduleModel
+
+@Serializable
+data class GetScheduleResponse(
+    val date: String,
+    val dailyTemperature: Int,
+    val schedules: List<ScheduleModel>
+)

--- a/feature/calendar/src/main/kotlin/team/noweekend/feature/calendar/component/choose/YearMonthCalendarTypeChooser.kt
+++ b/feature/calendar/src/main/kotlin/team/noweekend/feature/calendar/component/choose/YearMonthCalendarTypeChooser.kt
@@ -17,7 +17,7 @@ import androidx.compose.ui.unit.dp
 import kotlinx.datetime.LocalDate
 import team.noweekend.core.common.kotlin.extension.now
 import team.noweekend.core.common.ui.calendar.component.CalendarTypeToggle
-import team.noweekend.core.common.ui.calendar.state.CalendarPagerState.CalendarMode
+import team.noweekend.core.common.ui.calendar.model.CalendarMode
 import team.noweekend.core.design.system.foundation.theme.NWKTheme
 
 @Composable

--- a/feature/calendar/src/main/kotlin/team/noweekend/feature/calendar/component/todoList/CalendarTodoBoardDivider.kt
+++ b/feature/calendar/src/main/kotlin/team/noweekend/feature/calendar/component/todoList/CalendarTodoBoardDivider.kt
@@ -26,13 +26,6 @@ fun CalendarTodoBoardDivider(
 
     val isCanScrollBackward = remember { derivedStateOf { state.canScrollBackward } }
 
-    LaunchedEffect(Unit) {
-        snapshotFlow { state.canScrollBackward }.collect {
-            println(it)
-
-        }
-    }
-
     // 색상 애니메이션 정의
     val startColor = NWKTheme.color.Neutral.neutralGray100
     val endColor by animateColorAsState(

--- a/feature/calendar/src/main/kotlin/team/noweekend/feature/calendar/model/mapper/CalendarImageTypeMapper.kt
+++ b/feature/calendar/src/main/kotlin/team/noweekend/feature/calendar/model/mapper/CalendarImageTypeMapper.kt
@@ -1,0 +1,15 @@
+package team.noweekend.feature.calendar.model.mapper
+
+import team.noweekend.core.common.ui.calendar.model.CalendarImageType
+import team.noweekend.core.model.calendar.ImageType
+
+fun ImageType.toImageTypeWithId(): CalendarImageType {
+    return when (this) {
+        ImageType.NONE -> CalendarImageType.NONE
+        ImageType.REST -> CalendarImageType.Rest
+        ImageType.BURN_OUT -> CalendarImageType.BurnOut
+        ImageType.FUTURE_SCHEDULE -> CalendarImageType.FutureSchedule
+        ImageType.OVER_FIFTY_UNDER_SEVENTY_FIVE_DEGREE -> CalendarImageType.OverFiftyUnderSeventyFiveDegree
+        ImageType.OVER_ZERO_UNDER_FIFTY_DEGREE -> CalendarImageType.OverZeroUnderFiftyDegree
+    }
+}

--- a/feature/calendar/src/main/kotlin/team/noweekend/feature/calendar/mvi/CalendarIntent.kt
+++ b/feature/calendar/src/main/kotlin/team/noweekend/feature/calendar/mvi/CalendarIntent.kt
@@ -1,0 +1,29 @@
+package team.noweekend.feature.calendar.mvi
+
+import team.noweekend.core.common.android.mvi.Intent
+import team.noweekend.core.common.ui.calendar.model.CalendarDateOfWeek
+import team.noweekend.core.common.ui.calendar.model.CalendarMode
+
+sealed interface CalendarIntent : Intent {
+
+    data class InitCalendar(val initPage: Int) : CalendarIntent
+    data class UpdatePreviousWeeksData(val page: Int) : CalendarIntent
+    data class UpdateNextWeeksData(val page: Int) : CalendarIntent
+    data class UpdatePreviousMonthsData(val page: Int) : CalendarIntent
+    data class UpdateNextMonthsData(val page: Int) : CalendarIntent
+
+    data class UpdateTargetDate(val calendarDateOfWeek: CalendarDateOfWeek) : CalendarIntent
+    data class UpdateChooserMonth(
+        val page: Int,
+        val calendarMode: CalendarMode,
+    ) : CalendarIntent
+
+    data object UpdateCalendarData : CalendarIntent
+    data object CollectCalendarEvent : CalendarIntent
+
+    data object UpdateCalendarMode : CalendarIntent
+    data class UpdateCalendarModeWithToggleState(val isMonth: Boolean) : CalendarIntent
+
+    data class UpdateCalendarDataAndChooser(val page: Int, val calendarMode: CalendarMode) : CalendarIntent
+
+}

--- a/feature/calendar/src/main/kotlin/team/noweekend/feature/calendar/mvi/CalendarSideEffect.kt
+++ b/feature/calendar/src/main/kotlin/team/noweekend/feature/calendar/mvi/CalendarSideEffect.kt
@@ -1,0 +1,14 @@
+package team.noweekend.feature.calendar.mvi
+
+import team.noweekend.core.common.android.mvi.SideEffect
+
+sealed interface CalendarSideEffect : SideEffect {
+    data object CompleteInitMonthCalendar : CalendarSideEffect
+    data object CompleteInitWeekCalendar : CalendarSideEffect
+
+    data object CollectWeekPagerStatePage : CalendarSideEffect
+    data object CollectMonthPagerStatePage : CalendarSideEffect
+    data class UpdateWeekCalendar(val currentPage: Int) : CalendarSideEffect
+    data class UpdateMonthCalendar(val currentPage : Int) :CalendarSideEffect
+
+}

--- a/feature/calendar/src/main/kotlin/team/noweekend/feature/calendar/mvi/CalendarSideEffectHandler.kt
+++ b/feature/calendar/src/main/kotlin/team/noweekend/feature/calendar/mvi/CalendarSideEffectHandler.kt
@@ -1,0 +1,101 @@
+package team.noweekend.feature.calendar.mvi
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.snapshotFlow
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import team.noweekend.core.common.android.mvi.SideEffectHandler
+import team.noweekend.core.common.ui.calendar.state.CalendarPagerState
+import team.noweekend.core.common.ui.calendar.state.rememberCalendarPagerState
+
+@Composable
+fun rememberSideEffectHandler(
+    scrollToInitialWeekPage: () -> Unit,
+    scrollToMonthPage: () -> Unit,
+    collectMonthPagerData: (Int) -> Unit,
+    collectWeekPagerData: (Int) -> Unit,
+    updatePreviousWeekPage: (page: Int) -> Unit,
+    updateNextWeekPage: (page: Int) -> Unit,
+    updatePreviousMonthPage: (page: Int) -> Unit,
+    updateNextMonthPage: (page: Int) -> Unit,
+    calendarPagerState: CalendarPagerState = rememberCalendarPagerState(),
+    coroutineScope: CoroutineScope = rememberCoroutineScope(),
+) = remember(calendarPagerState, coroutineScope) {
+
+    CalendarSideEffectHandler(
+        scrollToInitialWeekPage = scrollToInitialWeekPage,
+        scrollToMonthPage = scrollToMonthPage,
+        collectWeekPagerData = collectWeekPagerData,
+        collectMonthPagerData = collectMonthPagerData,
+        updateNextMonthPage = updateNextMonthPage,
+        updatePreviousMonthPage = updatePreviousMonthPage,
+        updateNextWeekPage = updateNextWeekPage,
+        updatePreviousWeekPage = updatePreviousWeekPage,
+        calendarPagerState = calendarPagerState,
+        coroutineScope = coroutineScope,
+    )
+}
+
+@Stable
+class CalendarSideEffectHandler(
+    private val scrollToInitialWeekPage: () -> Unit,
+    private val scrollToMonthPage: () -> Unit,
+    private val collectMonthPagerData: (Int) -> Unit,
+    private val collectWeekPagerData: (Int) -> Unit,
+    private val updatePreviousWeekPage: (page: Int) -> Unit,
+    private val updateNextWeekPage: (page: Int) -> Unit,
+    private val updatePreviousMonthPage: (page: Int) -> Unit,
+    private val updateNextMonthPage: (page: Int) -> Unit,
+    private val calendarPagerState: CalendarPagerState,
+    private val coroutineScope: CoroutineScope,
+) : SideEffectHandler<CalendarSideEffect> {
+
+    override fun handleSideEffect(sideEffect: CalendarSideEffect) {
+        when (sideEffect) {
+            is CalendarSideEffect.CompleteInitWeekCalendar -> {
+                scrollToInitialWeekPage()
+            }
+
+            is CalendarSideEffect.CompleteInitMonthCalendar -> {
+                scrollToMonthPage()
+
+            }
+
+            is CalendarSideEffect.CollectMonthPagerStatePage -> {
+                coroutineScope.launch {
+                    snapshotFlow { calendarPagerState.monthPagerState.currentPage }.collect { page ->
+                        collectMonthPagerData(page)
+                    }
+                }
+            }
+
+            is CalendarSideEffect.CollectWeekPagerStatePage -> {
+                coroutineScope.launch {
+                    snapshotFlow { calendarPagerState.weekPagerState.currentPage }.collect { page ->
+                        collectWeekPagerData(page)
+                    }
+                }
+            }
+
+            is CalendarSideEffect.UpdateWeekCalendar -> {
+                calendarPagerState.updateWeekCalendar(
+                    currentPage = sideEffect.currentPage,
+                    updatePreviousWeekPage = updatePreviousWeekPage,
+                    updateNextWeekPage = updateNextWeekPage,
+                )
+
+            }
+
+            is CalendarSideEffect.UpdateMonthCalendar -> {
+                calendarPagerState.updateMonthCalendar(
+                    currentPage = sideEffect.currentPage,
+                    updateNextMonthPage = updateNextMonthPage,
+                    updatePreviousMonthPage = updatePreviousMonthPage,
+                )
+            }
+        }
+    }
+}

--- a/feature/calendar/src/main/kotlin/team/noweekend/feature/calendar/mvi/CalendarUiState.kt
+++ b/feature/calendar/src/main/kotlin/team/noweekend/feature/calendar/mvi/CalendarUiState.kt
@@ -1,0 +1,30 @@
+package team.noweekend.feature.calendar.mvi
+
+import androidx.compose.runtime.Immutable
+import kotlinx.collections.immutable.ImmutableMap
+import kotlinx.collections.immutable.persistentMapOf
+import kotlinx.datetime.LocalDate
+import team.noweekend.core.common.android.mvi.UiState
+import team.noweekend.core.common.kotlin.extension.now
+import team.noweekend.core.common.ui.calendar.model.CalendarMode
+import team.noweekend.core.common.ui.calendar.model.CalendarWeeksData
+
+
+@Immutable
+data class CalendarUiState(
+    val chooserMonth: LocalDate,
+    val selectedDate: LocalDate,
+    val calendarMode: CalendarMode,
+    val calendarWeeksData : ImmutableMap<Int, CalendarWeeksData>,
+    val calendarMonthsData : ImmutableMap<Int, CalendarWeeksData>
+) : UiState {
+    companion object {
+        val default = CalendarUiState(
+            chooserMonth = LocalDate.now(),
+            selectedDate = LocalDate.now(),
+            calendarWeeksData = persistentMapOf(),
+            calendarMonthsData = persistentMapOf(),
+            calendarMode = CalendarMode.WEEK
+        )
+    }
+}

--- a/feature/calendar/src/main/kotlin/team/noweekend/feature/calendar/mvi/CalendarViewModel.kt
+++ b/feature/calendar/src/main/kotlin/team/noweekend/feature/calendar/mvi/CalendarViewModel.kt
@@ -1,0 +1,246 @@
+package team.noweekend.feature.calendar.mvi
+
+import androidx.lifecycle.SavedStateHandle
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.toImmutableList
+import kotlinx.collections.immutable.toImmutableMap
+import kotlinx.coroutines.flow.combine
+import kotlinx.datetime.LocalDate
+import team.noweekend.core.common.android.base.MVIViewModel
+import team.noweekend.core.common.kotlin.extension.now
+import team.noweekend.core.common.ui.calendar.model.CalendarDateOfWeek
+import team.noweekend.core.common.ui.calendar.model.CalendarMode
+import team.noweekend.core.common.ui.calendar.model.CalendarWeeksData
+import team.noweekend.core.domain.usecase.CalendarDataProviderUseCase
+import team.noweekend.feature.calendar.model.mapper.toImageTypeWithId
+import javax.inject.Inject
+
+@HiltViewModel
+class CalendarViewModel @Inject constructor(
+    private val calendarDataProviderUseCase: CalendarDataProviderUseCase,
+    savedStateHandle: SavedStateHandle,
+) : MVIViewModel<CalendarIntent, CalendarSideEffect, CalendarUiState>(savedStateHandle = savedStateHandle) {
+
+    override fun createInitialState(savedStateHandle: SavedStateHandle): CalendarUiState {
+        return CalendarUiState.default.copy(
+            selectedDate = LocalDate.now(),
+        )
+    }
+
+    override fun handleClientException(throwable: Throwable) {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun handleIntent(intent: CalendarIntent) {
+        when (intent) {
+            is CalendarIntent.CollectCalendarEvent -> collectCalendarEvent()
+            is CalendarIntent.UpdateCalendarDataAndChooser -> updateChooserAndSendUpdateCalenderSideEffect(
+                page = intent.page,
+                calendarMode = intent.calendarMode,
+            )
+
+            is CalendarIntent.UpdateCalendarData -> updateCalendarData()
+            is CalendarIntent.UpdateTargetDate -> updateTargetDate(calendarDateOfWeek = intent.calendarDateOfWeek)
+            is CalendarIntent.UpdateChooserMonth -> updateChooserMonth(
+                calendarMode = intent.calendarMode,
+                page = intent.page,
+            )
+            is CalendarIntent.UpdateNextWeeksData -> updateNextWeeksData(currentPage = intent.page)
+            is CalendarIntent.UpdatePreviousWeeksData -> updatePreviousWeeksData(currentPage = intent.page)
+            is CalendarIntent.UpdateNextMonthsData -> updateNextMonthsData(currentPage = intent.page)
+            is CalendarIntent.UpdatePreviousMonthsData -> updatePreviousMonthsData(currentPage = intent.page)
+            is CalendarIntent.UpdateCalendarMode -> updateCalendarMode()
+            is CalendarIntent.UpdateCalendarModeWithToggleState -> updateCalendarMode(isMonth = intent.isMonth)
+            is CalendarIntent.InitCalendar -> initCalendar(initPage = intent.initPage)
+        }
+    }
+
+    private fun initCalendar(initPage: Int) = execute {
+        when(currentState.calendarMode){
+            CalendarMode.WEEK->{
+                initWeekCalendar(initPage)
+            }
+            CalendarMode.MONTH->{
+                initMonthCalendar(initPage)
+            }
+        }
+
+    }
+
+    private suspend fun initWeekCalendar(initPage: Int) {
+        calendarDataProviderUseCase.initWeekCalendar(initPage = initPage)
+        postSideEffect(sideEffect = CalendarSideEffect.CollectWeekPagerStatePage)
+
+    }
+
+    private suspend fun initMonthCalendar(initPage: Int)  {
+        calendarDataProviderUseCase.initMonthCalendar(page = initPage, currentState.chooserMonth)
+        postSideEffect(sideEffect = CalendarSideEffect.CollectMonthPagerStatePage)
+    }
+
+    private fun updateNextWeeksData(currentPage: Int) = execute {
+        calendarDataProviderUseCase.updateNextWeeksData(currentPage = currentPage)
+    }
+
+    private fun updatePreviousWeeksData(currentPage: Int) = execute {
+        calendarDataProviderUseCase.updatePreviousWeeksData(currentPage = currentPage)
+    }
+
+    private fun updateNextMonthsData(currentPage: Int) = execute {
+        calendarDataProviderUseCase.updateNextMonthData(currentPage = currentPage)
+    }
+
+    private fun updatePreviousMonthsData(currentPage: Int) = execute {
+        calendarDataProviderUseCase.updatePreviousMonthData(currentPage = currentPage)
+    }
+
+    private fun updateChooserMonth(
+        calendarMode: CalendarMode,
+        page: Int,
+    ) = execute {
+        when (calendarMode) {
+            CalendarMode.MONTH -> {
+                val currentMonthData = calendarDataProviderUseCase.getMonthData(page = page)
+                if (currentMonthData != null) {
+                    reduce {
+                        this.copy(
+                            chooserMonth = LocalDate(
+                                year = currentMonthData.year,
+                                monthNumber = currentMonthData.month,
+                                dayOfMonth = 1,
+                            ),
+                        )
+                    }
+                }
+            }
+
+            CalendarMode.WEEK -> {
+                val currentWeekData = calendarDataProviderUseCase.getWeeksData(page = page)
+                if (currentWeekData != null) {
+
+                    reduce {
+                        this.copy(
+                            chooserMonth = LocalDate(
+                                year = currentWeekData.year,
+                                monthNumber = currentWeekData.month,
+                                dayOfMonth = 1,
+                            ),
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    private fun updateTargetDate(calendarDateOfWeek: CalendarDateOfWeek) = execute {
+        val imageType = team.noweekend.core.model.calendar.ImageType.valueOf(
+            calendarDateOfWeek.calendarImageType.name,
+        )
+        val dateOfWeekModel = team.noweekend.core.model.calendar.DateOfWeek(
+            imageType = imageType,
+            localDate = calendarDateOfWeek.localDate,
+            isCurrentDate = calendarDateOfWeek.isCurrentDate,
+        )
+        calendarDataProviderUseCase.updateTargetDate(dateOfWeek = dateOfWeekModel)
+        reduce {
+            this.copy(
+                selectedDate = calendarDateOfWeek.localDate,
+            )
+        }
+    }
+
+    private fun updateCalendarData() = execute {
+        val weekDataFlow = calendarDataProviderUseCase.weeksDate
+        val monthDataFlow = calendarDataProviderUseCase.monthData
+        weekDataFlow.combine(monthDataFlow) { weekData, monthData ->
+            weekData to monthData
+        }.collect { (weekData, monthData) ->
+            reduce {
+                this.copy(
+                    calendarWeeksData = weekData.toList().associate { (key, value) ->
+                        key to CalendarWeeksData(
+                            year = value.year,
+                            month = value.month,
+                            calendarDateOfWeeks = value.dateOfWeeks.map { dateOfWeekList ->
+                                val calendarDateOfWeek = dateOfWeekList.map { dateOfWeek ->
+                                    CalendarDateOfWeek(
+                                        calendarImageType = dateOfWeek.imageType.toImageTypeWithId(),
+                                        localDate = dateOfWeek.localDate,
+                                        isCurrentDate = dateOfWeek.isCurrentDate,
+                                    )
+                                }.toImmutableList()
+                                calendarDateOfWeek
+                            }.toImmutableList(),
+                        )
+                    }.toImmutableMap(),
+                    calendarMonthsData = monthData.toList().associate { (key, value) ->
+                        key to CalendarWeeksData(
+                            year = value.year,
+                            month = value.month,
+                            calendarDateOfWeeks = value.dateOfWeeks.map { dateOfWeekList ->
+                                val calendarDateOfWeek = dateOfWeekList.map { dateOfWeek ->
+                                    CalendarDateOfWeek(
+                                        calendarImageType = dateOfWeek.imageType.toImageTypeWithId(),
+                                        localDate = dateOfWeek.localDate,
+                                        isCurrentDate = dateOfWeek.isCurrentDate,
+                                    )
+                                }.toImmutableList()
+                                calendarDateOfWeek
+                            }.toImmutableList(),
+                        )
+                    }.toImmutableMap(),
+                )
+            }
+        }
+    }
+
+    private fun collectCalendarEvent() = execute {
+        calendarDataProviderUseCase.calendarDataProviderEventFlow.collect { eventFlow ->
+            when (eventFlow) {
+                CalendarDataProviderUseCase.CalendarDataProviderEvent.CompleteInitMonthCalendar -> {
+                    postSideEffect(CalendarSideEffect.CompleteInitMonthCalendar)
+                }
+
+                CalendarDataProviderUseCase.CalendarDataProviderEvent.CompleteInitWeeksCalendar -> {
+                    postSideEffect(CalendarSideEffect.CompleteInitWeekCalendar)
+                }
+            }
+        }
+    }
+
+    private fun updateCalendarMode() = execute {
+        reduce {
+            this.copy(
+                calendarMode = if (this.calendarMode == CalendarMode.MONTH) CalendarMode.WEEK else CalendarMode.MONTH,
+            )
+        }
+    }
+
+    private fun updateCalendarMode(isMonth: Boolean) = execute {
+        reduce {
+            this.copy(
+                calendarMode = if (isMonth) CalendarMode.MONTH else CalendarMode.WEEK,
+            )
+        }
+    }
+
+    private fun updateChooserAndSendUpdateCalenderSideEffect(page: Int, calendarMode: CalendarMode) = execute {
+        intent(
+            CalendarIntent.UpdateChooserMonth(
+                page = page,
+                calendarMode = calendarMode,
+            ),
+        )
+
+        when (calendarMode) {
+            CalendarMode.WEEK -> {
+                postSideEffect(sideEffect = CalendarSideEffect.UpdateWeekCalendar(currentPage = page))
+            }
+
+            CalendarMode.MONTH -> {
+                postSideEffect(sideEffect = CalendarSideEffect.UpdateMonthCalendar(currentPage = page))
+            }
+        }
+    }
+
+}

--- a/feature/calendar/src/main/kotlin/team/noweekend/feature/calendar/mvi/builder/IntentBuilder.kt
+++ b/feature/calendar/src/main/kotlin/team/noweekend/feature/calendar/mvi/builder/IntentBuilder.kt
@@ -12,9 +12,7 @@ import team.noweekend.feature.calendar.mvi.CalendarIntent
 fun rememberIntentBuilder(
     send: (CalendarIntent) -> Unit,
 ) = remember {
-
     IntentBuilder(send = send)
-
 }
 
 @Stable

--- a/feature/calendar/src/main/kotlin/team/noweekend/feature/calendar/mvi/builder/IntentBuilder.kt
+++ b/feature/calendar/src/main/kotlin/team/noweekend/feature/calendar/mvi/builder/IntentBuilder.kt
@@ -1,0 +1,90 @@
+package team.noweekend.feature.calendar.mvi.builder
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.remember
+import team.noweekend.core.common.ui.calendar.model.CalendarDateOfWeek
+import team.noweekend.core.common.ui.calendar.model.CalendarMode
+import team.noweekend.feature.calendar.mvi.CalendarIntent
+
+
+@Composable
+fun rememberIntentBuilder(
+    send: (CalendarIntent) -> Unit,
+) = remember {
+
+    IntentBuilder(send = send)
+
+}
+
+@Stable
+class IntentBuilder(
+    private val send: (CalendarIntent) -> Unit,
+) {
+
+    private fun build(calendarIntent: CalendarIntent) {
+        send(calendarIntent)
+    }
+
+    fun updatePreviousWeekPage(page: Int) {
+        build(CalendarIntent.UpdatePreviousWeeksData(page = page))
+    }
+
+    fun updateNextWeekPage(page: Int) {
+        build(CalendarIntent.UpdateNextWeeksData(page = page))
+    }
+
+    fun updatePreviousMonthPage(page: Int) {
+        build(CalendarIntent.UpdatePreviousMonthsData(page = page))
+    }
+
+    fun updateNextMonthPage(page: Int) {
+        build(CalendarIntent.UpdateNextMonthsData(page = page))
+    }
+
+    fun updateWeekCalendarAndChooser(page: Int) {
+        build(
+            CalendarIntent.UpdateCalendarDataAndChooser(
+                page = page,
+                calendarMode = CalendarMode.WEEK,
+            ),
+        )
+    }
+
+    fun updateMonthCalendarAndChooser(page: Int) {
+        build(
+            CalendarIntent.UpdateCalendarDataAndChooser(
+                page = page,
+                calendarMode = CalendarMode.MONTH,
+            ),
+        )
+    }
+
+    fun updateCalendarMode() {
+        build(CalendarIntent.UpdateCalendarMode)
+    }
+
+    fun updateCalendarModeWithToggleState(isMonth: Boolean) {
+        build(CalendarIntent.UpdateCalendarModeWithToggleState(isMonth = isMonth))
+    }
+
+    fun updateTargetDate(calendarDateOfWeek: CalendarDateOfWeek) {
+        build(CalendarIntent.UpdateTargetDate(calendarDateOfWeek = calendarDateOfWeek))
+    }
+
+    fun collectCalendarEvent() {
+        build(CalendarIntent.CollectCalendarEvent)
+    }
+
+    fun updateCalendarData() {
+        build(CalendarIntent.UpdateCalendarData)
+    }
+
+    fun initCalendarData(
+        initPage: Int,
+    ) {
+        build(CalendarIntent.InitCalendar(initPage = initPage))
+
+    }
+
+}

--- a/feature/calendar/src/main/kotlin/team/noweekend/feature/calendar/screen/CalendarRoute.kt
+++ b/feature/calendar/src/main/kotlin/team/noweekend/feature/calendar/screen/CalendarRoute.kt
@@ -3,141 +3,97 @@ package team.noweekend.feature.calendar.screen
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
+import androidx.compose.runtime.State
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import kotlinx.coroutines.launch
-import kotlinx.datetime.LocalDate
-import team.noweekend.core.common.ui.calendar.CalendarDataProvider
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import team.noweekend.core.common.ui.calendar.model.CalendarMode
 import team.noweekend.core.common.ui.calendar.model.CalendarState
-import team.noweekend.core.common.ui.calendar.model.WeeksData
-import team.noweekend.core.common.ui.calendar.rememberCalendarDataProvider
-import team.noweekend.core.common.ui.calendar.state.CalendarPagerState
 import team.noweekend.core.common.ui.calendar.state.rememberCalendarPagerState
 import team.noweekend.core.common.ui.todo.model.Todo
 import team.noweekend.core.design.system.foundation.theme.NWKTheme
+import team.noweekend.feature.calendar.mvi.CalendarViewModel
+import team.noweekend.feature.calendar.mvi.builder.rememberIntentBuilder
+import team.noweekend.feature.calendar.mvi.rememberSideEffectHandler
 
 @Composable
 internal fun CalendarRoute(
     modifier: Modifier = Modifier,
+    calendarViewModel: CalendarViewModel = hiltViewModel(),
 ) {
 
-    val calendarDataProvider = rememberCalendarDataProvider()
     val calendarPagerState = rememberCalendarPagerState()
-    val selectedDate = calendarDataProvider.targetDate
+
+    val intentBuilder = rememberIntentBuilder { calendarIntent ->
+        calendarViewModel.intent(calendarIntent)
+    }
+
+    val state = calendarViewModel.uiState.collectAsStateWithLifecycle()
     val chooserMonth = remember {
-        mutableStateOf(selectedDate.value)
+        derivedStateOf {
+            state.value.chooserMonth
+        }
     }
-    val calendarMode: CalendarPagerState.CalendarMode by calendarPagerState.calendarMode.collectAsState()
 
-    val calendarState: CalendarState by remember(calendarMode) {
-        mutableStateOf(
-            when (calendarMode) {
-                CalendarPagerState.CalendarMode.WEEK -> {
+    val calendarSideEffectHandler = rememberSideEffectHandler(
+        calendarPagerState = calendarPagerState,
+        scrollToInitialWeekPage = calendarPagerState::scrollToInitialWeekPage,
+        scrollToMonthPage = calendarPagerState::scrollToMonthPage,
+        collectMonthPagerData = intentBuilder::updateMonthCalendarAndChooser,
+        collectWeekPagerData = intentBuilder::updateWeekCalendarAndChooser,
+        updateNextWeekPage = intentBuilder::updateNextWeekPage,
+        updateNextMonthPage = intentBuilder::updateNextMonthPage,
+        updatePreviousMonthPage = intentBuilder::updatePreviousMonthPage,
+        updatePreviousWeekPage = intentBuilder::updatePreviousWeekPage,
+    )
+
+    val calendarState: State<CalendarState> = remember {
+        derivedStateOf {
+            when (state.value.calendarMode) {
+                CalendarMode.WEEK -> {
                     CalendarState.Week(
-                        mode = calendarMode,
-                        selectedDate = selectedDate,
+                        mode = state.value.calendarMode,
+                        selectedDate = mutableStateOf(state.value.selectedDate),
                         pagerState = calendarPagerState.weekPagerState,
-                        pagerData = calendarDataProvider.weeksData,
+                        pagerData = state.value.calendarWeeksData,
                     )
                 }
 
-                CalendarPagerState.CalendarMode.MONTH -> {
+                CalendarMode.MONTH -> {
                     CalendarState.Month(
-                        mode = calendarMode,
-                        selectedDate = selectedDate,
+                        mode = state.value.calendarMode,
+                        selectedDate = mutableStateOf(state.value.selectedDate),
                         pagerState = calendarPagerState.monthPagerState,
-                        pagerData = calendarDataProvider.monthData,
+                        pagerData = state.value.calendarMonthsData,
                     )
                 }
-            },
-        )
+            }
+        }
     }
-
 
 
     LaunchedEffect(Unit) {
-        calendarDataProvider.calendarDataProviderEventFlow.collect { event ->
-            when (event) {
-                is CalendarDataProvider.CalendarDataProviderEvent.CompleteInitWeeksCalendar -> {
-                    calendarPagerState.scrollToInitialWeekPage()
-                }
-
-                is CalendarDataProvider.CalendarDataProviderEvent.CompleteInitMonthCalendar -> {
-                    calendarPagerState.scrollToMonthPage()
-                }
-            }
+        with(intentBuilder) {
+            collectCalendarEvent()
+            updateCalendarData()
         }
+        calendarViewModel.sideEffect.collect(calendarSideEffectHandler::handleSideEffect)
     }
-
-    LaunchedEffect(calendarMode) {
-        when (calendarMode) {
-            CalendarPagerState.CalendarMode.WEEK -> {
-                launch {
-                    calendarDataProvider.initWeekCalendar(initPage = calendarPagerState.initialPage)
-                    snapshotFlow {
-                        calendarPagerState.weekPagerState.currentPage
-                    }.collect { currentPage ->
-
-                        val currentWeekData: WeeksData? = calendarDataProvider.weeksData[currentPage]
-                        if (currentWeekData != null) {
-                            chooserMonth.value = LocalDate(
-                                year = currentWeekData.year,
-                                monthNumber = currentWeekData.month,
-                                dayOfMonth = 1,
-                            )
-                        }
-
-
-                        calendarPagerState.updateWeekCalendar(
-                            currentPage = currentPage,
-                            updatePreviousWeekPage = calendarDataProvider::updatePreviousWeeksData,
-                            updateNextWeekPage = calendarDataProvider::updateNextWeeksData,
-                        )
-                    }
-                }
-
-            }
-
-            CalendarPagerState.CalendarMode.MONTH -> {
-                launch {
-                    calendarDataProvider.initMonthCalendar(
-                        page = calendarPagerState.initialPage,
-                        chooserMonth = chooserMonth.value,
-                    )
-                    snapshotFlow { calendarPagerState.monthPagerState.currentPage }.collect { currentPage ->
-
-                        val currentWeekData: WeeksData? = calendarDataProvider.monthData[currentPage]
-                        if (currentWeekData != null) {
-                            chooserMonth.value = LocalDate(
-                                year = currentWeekData.year,
-                                monthNumber = currentWeekData.month,
-                                dayOfMonth = 1,
-                            )
-                        }
-
-                        calendarPagerState.updateMonthCalendar(
-                            currentPage = currentPage,
-                            updateNextMonthPage = calendarDataProvider::updateNextMonthData,
-                            updatePreviousMonthPage = calendarDataProvider::updatePreviousMonthData,
-                        )
-                    }
-                }
-            }
-        }
+    LaunchedEffect(state.value.calendarMode) {
+        intentBuilder.initCalendarData(calendarPagerState.initialPage)
     }
 
     CalendarScreen(
         modifier = modifier,
-        calendarState = calendarState,
+        calendarState = calendarState.value,
         chooserDate = chooserMonth,
-        onToggleStateChanged = calendarPagerState::updateCalendarMode,
-        onClickToggle = calendarPagerState::updateCalendarMode,
-        onClickDateOfWeek = calendarDataProvider::updateTargetDate,
+        onToggleStateChanged = intentBuilder::updateCalendarModeWithToggleState,
+        onClickToggle = intentBuilder::updateCalendarMode,
+        onClickDateOfWeek = intentBuilder::updateTargetDate,
         onClickYearMonthButton = {},
         onClickCheckBox = {},
         onClickOptionButton = {},

--- a/feature/calendar/src/main/kotlin/team/noweekend/feature/calendar/screen/CalendarRoute.kt
+++ b/feature/calendar/src/main/kotlin/team/noweekend/feature/calendar/screen/CalendarRoute.kt
@@ -5,7 +5,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.State
 import androidx.compose.runtime.derivedStateOf
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
@@ -57,7 +56,7 @@ internal fun CalendarRoute(
                 CalendarMode.WEEK -> {
                     CalendarState.Week(
                         mode = state.value.calendarMode,
-                        selectedDate = mutableStateOf(state.value.selectedDate),
+                        selectedDate = state.value.selectedDate,
                         pagerState = calendarPagerState.weekPagerState,
                         pagerData = state.value.calendarWeeksData,
                     )
@@ -66,7 +65,7 @@ internal fun CalendarRoute(
                 CalendarMode.MONTH -> {
                     CalendarState.Month(
                         mode = state.value.calendarMode,
-                        selectedDate = mutableStateOf(state.value.selectedDate),
+                        selectedDate = state.value.selectedDate,
                         pagerState = calendarPagerState.monthPagerState,
                         pagerData = state.value.calendarMonthsData,
                     )

--- a/feature/calendar/src/main/kotlin/team/noweekend/feature/calendar/screen/CalendarScreen.kt
+++ b/feature/calendar/src/main/kotlin/team/noweekend/feature/calendar/screen/CalendarScreen.kt
@@ -6,13 +6,14 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.datetime.LocalDate
+import team.noweekend.core.common.ui.calendar.model.CalendarDateOfWeek
+import team.noweekend.core.common.ui.calendar.model.CalendarMode
 import team.noweekend.core.common.ui.calendar.model.CalendarState
-import team.noweekend.core.common.ui.calendar.model.DateOfWeek
-import team.noweekend.core.common.ui.calendar.state.CalendarPagerState.CalendarMode
 import team.noweekend.core.common.ui.todo.model.Todo
 import team.noweekend.core.design.system.foundation.theme.NWKTheme
 import team.noweekend.feature.calendar.component.choose.YearMonthCalendarTypeChooser
@@ -22,7 +23,7 @@ import team.noweekend.feature.calendar.component.todoList.CalendarTodoList
 internal fun CalendarScreen(
     chooserDate: State<LocalDate>,
     calendarState: CalendarState,
-    onClickDateOfWeek: (DateOfWeek) -> Unit,
+    onClickDateOfWeek: (CalendarDateOfWeek) -> Unit,
     onClickYearMonthButton: () -> Unit,
     onClickToggle: () -> Unit,
     onToggleStateChanged: (Boolean) -> Unit,
@@ -31,6 +32,7 @@ internal fun CalendarScreen(
     modifier: Modifier = Modifier,
     todoList: ImmutableList<Todo> = persistentListOf(),
 ) {
+
 
     Column(
         modifier = modifier
@@ -47,7 +49,7 @@ internal fun CalendarScreen(
         NWKCalender(
             calendarState = calendarState,
             onClickDateOfWeek = onClickDateOfWeek,
-            userScrollEnabled = true
+            userScrollEnabled = true,
         )
         if (calendarState.mode == CalendarMode.WEEK) {
             CalendarTodoList(

--- a/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/recommend/model/RecommendedVacationUiModel.kt
+++ b/feature/create-vacation/src/main/kotlin/team/noweekend/feature/create/vacation/recommend/model/RecommendedVacationUiModel.kt
@@ -5,7 +5,7 @@ import kotlinx.datetime.LocalDate
 import team.noweekend.core.common.kotlin.extension.MONTH_DATE_WITH_DAY_OF_WEEK_PATTERN
 import team.noweekend.core.common.kotlin.extension.now
 import team.noweekend.core.common.kotlin.extension.toFormattedString
-import team.noweekend.core.common.ui.calendar.util.CalendarUtils.plusMonths
+import team.noweekend.core.common.kotlin.extension.CalendarUtils.plusMonths
 import team.noweekend.core.resource.NWKDrawableResource
 
 @Stable

--- a/feature/home/src/main/java/team/noweekend/feature/home/component/recommend/monthly/MonthlyVacationRecommendComponent.kt
+++ b/feature/home/src/main/java/team/noweekend/feature/home/component/recommend/monthly/MonthlyVacationRecommendComponent.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableMap
 import kotlinx.datetime.LocalDate
 import team.noweekend.core.common.kotlin.extension.now
 import team.noweekend.core.common.ui.calendar.model.CalendarState
@@ -63,9 +64,9 @@ internal fun MonthlyVacationRecommendComponent(
         )
         NWKCalender(
             calendarState = CalendarState.Week(
-                pagerData = calendarDataProvider.weeksData,
+                pagerData = calendarDataProvider.calendarWeeksData.toImmutableMap(),
                 pagerState = calendarPagerState.weekPagerState,
-                selectedDate = calendarDataProvider.targetDate,
+                selectedDate = calendarDataProvider.targetDate.value,
             ),
             onClickDateOfWeek = {},
             userScrollEnabled = false,


### PR DESCRIPTION
### What is this PR (Required)
- **Issue Number** : close #114
- **Figma :**
- 기타 관련 문서 :

### Changes (Required)
- calendar data provider를 안쓰기 위해서 domain에 calendarDataProviderUseCase 만듬
- calendarDataProviderUseCase에서 compose 의존성 제거 후 stateFlow로 변경
- api 관련 로직 추가. 연동해뒀으니 비슷하게? 
- model module안에는 calendar와 schedule관련한것들 넣어둠
- 해당 model로 domain에서 관리하돼, 다시 캘린더 ui로 mapping시도
- 코드 량이 많으니 미안해..

### Review Point (Required)
- 재성이 쪽은 다시 수정해야해. 어떻게 받는지 궁금하면 문의주소..
- 1300줄이라 딱 볼꺼는 calendarDataProviderUseCase만든 부분
- scheduleApi 연결한 것 
- mvi 부분? 이렇게 될꺼같아
- model 명을 수정한게 있어서 변경이 많아졌어 

### Screenshot
| 기능 | 스크린샷 |
| --- | --- |
| GIF | <img src="https://github.com/user-attachments/assets/8cafb96b-87b6-4278-aad6-3225d5315f3f" width="300" /> |


### 관련 Reference 자료
-