### PR TITLE
[#124] 홈 인기 휴가 API 연결 및 UI 수정

### DIFF
--- a/core/data/src/main/java/team/noweekend/data/di/RepositoryModule.kt
+++ b/core/data/src/main/java/team/noweekend/data/di/RepositoryModule.kt
@@ -10,12 +10,14 @@ import team.noweekend.core.domain.repository.LocationRepository
 import team.noweekend.core.domain.repository.LoginRepository
 import team.noweekend.core.domain.repository.RecommendRepository
 import team.noweekend.core.domain.repository.ScheduleRepository
+import team.noweekend.core.domain.repository.UserRepository
 import team.noweekend.data.repository.AuthRepositoryImpl
 import team.noweekend.data.repository.HolidayRepositoryImpl
 import team.noweekend.data.repository.LocationRepositoryImpl
 import team.noweekend.data.repository.LoginRepositoryImpl
 import team.noweekend.data.repository.RecommendRepositoryImpl
 import team.noweekend.data.repository.ScheduleRepositoryImpl
+import team.noweekend.data.repository.UserRepositoryImpl
 import javax.inject.Singleton
 
 @Module
@@ -45,4 +47,8 @@ internal interface RepositoryModule {
     @Singleton
     @Binds
     fun bindLoginRepository(loginRepositoryImpl: LoginRepositoryImpl): LoginRepository
+
+    @Singleton
+    @Binds
+    fun bindUserRepository(impl: UserRepositoryImpl): UserRepository
 }

--- a/core/data/src/main/java/team/noweekend/data/mapper/RecommendMapper.kt
+++ b/core/data/src/main/java/team/noweekend/data/mapper/RecommendMapper.kt
@@ -1,10 +1,18 @@
 package team.noweekend.data.mapper
 
+import team.noweekend.core.model.vacation.SandwichRecommendVacation
 import team.noweekend.core.model.vacation.WeatherRecommendVacation
+import team.noweekend.core.remote.model.recommend.SandwichRecommendResponse
 import team.noweekend.core.remote.model.recommend.WeatherRecommendResponseDto
 
 internal fun WeatherRecommendResponseDto.toDomain(): WeatherRecommendVacation =
     WeatherRecommendVacation(
         date = date,
         content = content,
+    )
+
+internal fun SandwichRecommendResponse.toDomain(): SandwichRecommendVacation =
+    SandwichRecommendVacation(
+        startDate = startDate,
+        endDate = endDate,
     )

--- a/core/data/src/main/java/team/noweekend/data/mapper/UserMapper.kt
+++ b/core/data/src/main/java/team/noweekend/data/mapper/UserMapper.kt
@@ -1,0 +1,20 @@
+package team.noweekend.data.mapper
+
+import team.noweekend.core.model.user.User
+import team.noweekend.core.remote.model.user.UserProfileResponse
+
+internal fun UserProfileResponse.toDomain(): User = User(
+    userId = userId,
+    userEmail = userEmail,
+    userName = userName,
+    userGender = userGender,
+    userBirth = userBirth,
+    oAuthId = oAuthId,
+    oAuthType = oAuthType,
+    revocableToken = revocableToken,
+    role = role,
+    remainingAnnualLeave = remainingAnnualLeave,
+    latitude = location.latitude,
+    longitude = location.longitude,
+    averageTemperature = averageTemperature,
+)

--- a/core/data/src/main/java/team/noweekend/data/model/LoginInfoDataModel.kt
+++ b/core/data/src/main/java/team/noweekend/data/model/LoginInfoDataModel.kt
@@ -1,7 +1,7 @@
 package team.noweekend.data.model
 
 import team.noweekend.core.model.login.LoginInfoDomainModel
-import team.noweekend.core.remote.model.LoginResponse
+import team.noweekend.core.remote.model.login.LoginResponse
 
 data class LoginInfoDataModel(
     val exists: Boolean,

--- a/core/data/src/main/java/team/noweekend/data/repository/LoginRepositoryImpl.kt
+++ b/core/data/src/main/java/team/noweekend/data/repository/LoginRepositoryImpl.kt
@@ -3,8 +3,8 @@ package team.noweekend.data.repository
 import team.noweekend.core.domain.repository.LoginRepository
 import team.noweekend.core.model.login.LoginInfoDomainModel
 import team.noweekend.core.model.login.LoginRequest
-import team.noweekend.core.remote.api.LoginApi
-import team.noweekend.core.remote.model.LoginRequestBody
+import team.noweekend.core.remote.api.login.LoginApi
+import team.noweekend.core.remote.model.login.LoginRequestBody
 import team.noweekend.data.model.toDataModel
 import javax.inject.Inject
 

--- a/core/data/src/main/java/team/noweekend/data/repository/RecommendRepositoryImpl.kt
+++ b/core/data/src/main/java/team/noweekend/data/repository/RecommendRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package team.noweekend.data.repository
 
 import team.noweekend.core.domain.repository.RecommendRepository
+import team.noweekend.core.model.vacation.SandwichRecommendVacation
 import team.noweekend.core.model.vacation.WeatherRecommendVacation
 import team.noweekend.core.remote.api.recommend.RecommendApi
 import team.noweekend.data.mapper.toDomain
@@ -11,5 +12,9 @@ internal class RecommendRepositoryImpl @Inject constructor(
 ) : RecommendRepository {
     override suspend fun getWeatherRecommendVacation(): List<WeatherRecommendVacation> {
         return recommendApi.getWeatherRecommendVacation().weatherRecommendations.map { it.toDomain() }
+    }
+
+    override suspend fun getSandwichRecommendVacation(): SandwichRecommendVacation {
+        return recommendApi.getSandwichRecommendVacation().toDomain()
     }
 }

--- a/core/data/src/main/java/team/noweekend/data/repository/UserRepositoryImpl.kt
+++ b/core/data/src/main/java/team/noweekend/data/repository/UserRepositoryImpl.kt
@@ -1,0 +1,15 @@
+package team.noweekend.data.repository
+
+import team.noweekend.core.domain.repository.UserRepository
+import team.noweekend.core.model.user.User
+import team.noweekend.core.remote.api.user.UserApi
+import team.noweekend.data.mapper.toDomain
+import javax.inject.Inject
+
+class UserRepositoryImpl @Inject constructor(
+    private val userApi: UserApi,
+) : UserRepository {
+    override suspend fun getUserProfile(): User {
+        return userApi.getUserProfile().toDomain()
+    }
+}

--- a/core/domain/src/main/java/team/noweekend/core/domain/repository/RecommendRepository.kt
+++ b/core/domain/src/main/java/team/noweekend/core/domain/repository/RecommendRepository.kt
@@ -1,7 +1,9 @@
 package team.noweekend.core.domain.repository
 
+import team.noweekend.core.model.vacation.SandwichRecommendVacation
 import team.noweekend.core.model.vacation.WeatherRecommendVacation
 
 interface RecommendRepository {
     suspend fun getWeatherRecommendVacation(): List<WeatherRecommendVacation>
+    suspend fun getSandwichRecommendVacation(): SandwichRecommendVacation
 }

--- a/core/domain/src/main/java/team/noweekend/core/domain/repository/UserRepository.kt
+++ b/core/domain/src/main/java/team/noweekend/core/domain/repository/UserRepository.kt
@@ -1,0 +1,7 @@
+package team.noweekend.core.domain.repository
+
+import team.noweekend.core.model.user.User
+
+interface UserRepository {
+    suspend fun getUserProfile(): User
+}

--- a/core/domain/src/main/java/team/noweekend/core/domain/usecase/GetSandwichRecommendVacationUseCase.kt
+++ b/core/domain/src/main/java/team/noweekend/core/domain/usecase/GetSandwichRecommendVacationUseCase.kt
@@ -1,0 +1,13 @@
+package team.noweekend.core.domain.usecase
+
+import team.noweekend.core.domain.repository.RecommendRepository
+import team.noweekend.core.model.vacation.SandwichRecommendVacation
+import javax.inject.Inject
+
+class GetSandwichRecommendVacationUseCase @Inject constructor(
+    private val repository: RecommendRepository,
+) {
+    suspend operator fun invoke(): Result<SandwichRecommendVacation> = runCatching {
+        repository.getSandwichRecommendVacation()
+    }
+}

--- a/core/domain/src/main/java/team/noweekend/core/domain/usecase/GetUserProfileUseCase.kt
+++ b/core/domain/src/main/java/team/noweekend/core/domain/usecase/GetUserProfileUseCase.kt
@@ -1,0 +1,13 @@
+package team.noweekend.core.domain.usecase
+
+import team.noweekend.core.domain.repository.UserRepository
+import team.noweekend.core.model.user.User
+import javax.inject.Inject
+
+class GetUserProfileUseCase @Inject constructor(
+    private val repository: UserRepository,
+) {
+    suspend operator fun invoke(): Result<User> = runCatching {
+        repository.getUserProfile()
+    }
+}

--- a/core/model/src/main/java/team/noweekend/core/model/user/User.kt
+++ b/core/model/src/main/java/team/noweekend/core/model/user/User.kt
@@ -1,0 +1,17 @@
+package team.noweekend.core.model.user
+
+data class User(
+    val userId: String,
+    val userEmail: String,
+    val userName: String,
+    val userGender: String,
+    val userBirth: String,
+    val oAuthId: String,
+    val oAuthType: String,
+    val revocableToken: String,
+    val role: String,
+    val remainingAnnualLeave: Float,
+    val latitude: Float,
+    val longitude: Float,
+    val averageTemperature: Float,
+)

--- a/core/model/src/main/java/team/noweekend/core/model/vacation/SandwichRecommendVacation.kt
+++ b/core/model/src/main/java/team/noweekend/core/model/vacation/SandwichRecommendVacation.kt
@@ -1,0 +1,6 @@
+package team.noweekend.core.model.vacation
+
+data class SandwichRecommendVacation(
+    val startDate: String,
+    val endDate: String,
+)

--- a/core/remote/src/main/kotlin/team/noweekend/core/remote/api/LoginApi.kt
+++ b/core/remote/src/main/kotlin/team/noweekend/core/remote/api/LoginApi.kt
@@ -1,8 +1,0 @@
-package team.noweekend.core.remote.api
-
-import team.noweekend.core.remote.model.LoginRequestBody
-import team.noweekend.core.remote.model.LoginResponse
-
-interface LoginApi {
-    suspend fun requestLogin(requestBody: LoginRequestBody): LoginResponse
-}

--- a/core/remote/src/main/kotlin/team/noweekend/core/remote/api/location/LocationApiImpl.kt
+++ b/core/remote/src/main/kotlin/team/noweekend/core/remote/api/location/LocationApiImpl.kt
@@ -2,7 +2,7 @@ package team.noweekend.core.remote.api.location
 
 import io.ktor.client.HttpClient
 import team.noweekend.core.remote.base.postApiCall
-import team.noweekend.core.remote.model.location.UserLocationRequestDto
+import team.noweekend.core.remote.model.location.UserLocationDto
 import team.noweekend.core.remote.qualifier.BasicClient
 import javax.inject.Inject
 
@@ -12,7 +12,7 @@ class LocationApiImpl @Inject constructor(
     override suspend fun postUserLocation(latitude: Float, longitude: Float) {
         client.postApiCall<String>(
             path = "/api/v1/user/location",
-            body = UserLocationRequestDto(latitude = latitude, longitude = longitude),
+            body = UserLocationDto(latitude = latitude, longitude = longitude),
         )
     }
 }

--- a/core/remote/src/main/kotlin/team/noweekend/core/remote/api/login/LoginApi.kt
+++ b/core/remote/src/main/kotlin/team/noweekend/core/remote/api/login/LoginApi.kt
@@ -1,0 +1,8 @@
+package team.noweekend.core.remote.api.login
+
+import team.noweekend.core.remote.model.login.LoginRequestBody
+import team.noweekend.core.remote.model.login.LoginResponse
+
+interface LoginApi {
+    suspend fun requestLogin(requestBody: LoginRequestBody): LoginResponse
+}

--- a/core/remote/src/main/kotlin/team/noweekend/core/remote/api/login/LoginApiImpl.kt
+++ b/core/remote/src/main/kotlin/team/noweekend/core/remote/api/login/LoginApiImpl.kt
@@ -1,9 +1,9 @@
-package team.noweekend.core.remote.api
+package team.noweekend.core.remote.api.login
 
 import io.ktor.client.HttpClient
 import team.noweekend.core.remote.base.postApiCall
-import team.noweekend.core.remote.model.LoginRequestBody
-import team.noweekend.core.remote.model.LoginResponse
+import team.noweekend.core.remote.model.login.LoginRequestBody
+import team.noweekend.core.remote.model.login.LoginResponse
 import team.noweekend.core.remote.qualifier.BasicClient
 import javax.inject.Inject
 

--- a/core/remote/src/main/kotlin/team/noweekend/core/remote/api/recommend/RecommendApi.kt
+++ b/core/remote/src/main/kotlin/team/noweekend/core/remote/api/recommend/RecommendApi.kt
@@ -1,7 +1,9 @@
 package team.noweekend.core.remote.api.recommend
 
+import team.noweekend.core.remote.model.recommend.SandwichRecommendResponse
 import team.noweekend.core.remote.model.recommend.WeatherRecommendResponse
 
 interface RecommendApi {
     suspend fun getWeatherRecommendVacation(): WeatherRecommendResponse
+    suspend fun getSandwichRecommendVacation(): SandwichRecommendResponse
 }

--- a/core/remote/src/main/kotlin/team/noweekend/core/remote/api/recommend/RecommendApiImpl.kt
+++ b/core/remote/src/main/kotlin/team/noweekend/core/remote/api/recommend/RecommendApiImpl.kt
@@ -2,6 +2,7 @@ package team.noweekend.core.remote.api.recommend
 
 import io.ktor.client.HttpClient
 import team.noweekend.core.remote.base.getApiCall
+import team.noweekend.core.remote.model.recommend.SandwichRecommendResponse
 import team.noweekend.core.remote.model.recommend.WeatherRecommendResponse
 import team.noweekend.core.remote.qualifier.BasicClient
 import javax.inject.Inject
@@ -11,5 +12,9 @@ class RecommendApiImpl @Inject constructor(
 ) : RecommendApi {
     override suspend fun getWeatherRecommendVacation(): WeatherRecommendResponse {
         return client.getApiCall(path = "/api/v1/recommend/weather")
+    }
+
+    override suspend fun getSandwichRecommendVacation(): SandwichRecommendResponse {
+        return client.getApiCall(path = "/api/v1/recommend/sandwich")
     }
 }

--- a/core/remote/src/main/kotlin/team/noweekend/core/remote/api/user/UserApi.kt
+++ b/core/remote/src/main/kotlin/team/noweekend/core/remote/api/user/UserApi.kt
@@ -1,5 +1,7 @@
 package team.noweekend.core.remote.api.user
 
+import team.noweekend.core.remote.model.user.UserProfileResponse
+
 interface UserApi {
-    suspend fun getUserProfile()
+    suspend fun getUserProfile(): UserProfileResponse
 }

--- a/core/remote/src/main/kotlin/team/noweekend/core/remote/api/user/UserApi.kt
+++ b/core/remote/src/main/kotlin/team/noweekend/core/remote/api/user/UserApi.kt
@@ -1,0 +1,5 @@
+package team.noweekend.core.remote.api.user
+
+interface UserApi {
+    suspend fun getUserProfile()
+}

--- a/core/remote/src/main/kotlin/team/noweekend/core/remote/api/user/UserApiImpl.kt
+++ b/core/remote/src/main/kotlin/team/noweekend/core/remote/api/user/UserApiImpl.kt
@@ -1,0 +1,15 @@
+package team.noweekend.core.remote.api.user
+
+import io.ktor.client.HttpClient
+import team.noweekend.core.remote.base.getApiCall
+import team.noweekend.core.remote.model.user.UserProfileResponse
+import team.noweekend.core.remote.qualifier.BasicClient
+import javax.inject.Inject
+
+class UserApiImpl @Inject constructor(
+    @BasicClient val client: HttpClient,
+) : UserApi {
+    override suspend fun getUserProfile(): UserProfileResponse {
+        return client.getApiCall(path = "/api/v1/user")
+    }
+}

--- a/core/remote/src/main/kotlin/team/noweekend/core/remote/di/NetworkApiModule.kt
+++ b/core/remote/src/main/kotlin/team/noweekend/core/remote/di/NetworkApiModule.kt
@@ -4,16 +4,18 @@ import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
-import team.noweekend.core.remote.api.login.LoginApi
-import team.noweekend.core.remote.api.login.LoginApiImpl
 import team.noweekend.core.remote.api.holiday.HolidayApi
 import team.noweekend.core.remote.api.holiday.HolidayApiImpl
 import team.noweekend.core.remote.api.location.LocationApi
 import team.noweekend.core.remote.api.location.LocationApiImpl
+import team.noweekend.core.remote.api.login.LoginApi
+import team.noweekend.core.remote.api.login.LoginApiImpl
 import team.noweekend.core.remote.api.recommend.RecommendApi
 import team.noweekend.core.remote.api.recommend.RecommendApiImpl
 import team.noweekend.core.remote.api.schedule.ScheduleApi
 import team.noweekend.core.remote.api.schedule.ScheduleApiImpl
+import team.noweekend.core.remote.api.user.UserApi
+import team.noweekend.core.remote.api.user.UserApiImpl
 import javax.inject.Singleton
 
 @Module
@@ -39,4 +41,8 @@ internal interface NetworkApiModule {
     @Binds
     @Singleton
     fun bindLocationApi(impl: LocationApiImpl): LocationApi
+
+    @Binds
+    @Singleton
+    fun bindUserApi(impl: UserApiImpl): UserApi
 }

--- a/core/remote/src/main/kotlin/team/noweekend/core/remote/di/NetworkApiModule.kt
+++ b/core/remote/src/main/kotlin/team/noweekend/core/remote/di/NetworkApiModule.kt
@@ -4,8 +4,8 @@ import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
-import team.noweekend.core.remote.api.LoginApi
-import team.noweekend.core.remote.api.LoginApiImpl
+import team.noweekend.core.remote.api.login.LoginApi
+import team.noweekend.core.remote.api.login.LoginApiImpl
 import team.noweekend.core.remote.api.holiday.HolidayApi
 import team.noweekend.core.remote.api.holiday.HolidayApiImpl
 import team.noweekend.core.remote.api.location.LocationApi

--- a/core/remote/src/main/kotlin/team/noweekend/core/remote/model/location/UserLocationDto.kt
+++ b/core/remote/src/main/kotlin/team/noweekend/core/remote/model/location/UserLocationDto.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class UserLocationRequestDto(
+data class UserLocationDto(
     @SerialName("latitude")
     val latitude: Float,
     @SerialName("longitude")

--- a/core/remote/src/main/kotlin/team/noweekend/core/remote/model/login/LoginRequestBody.kt
+++ b/core/remote/src/main/kotlin/team/noweekend/core/remote/model/login/LoginRequestBody.kt
@@ -1,4 +1,4 @@
-package team.noweekend.core.remote.model
+package team.noweekend.core.remote.model.login
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable

--- a/core/remote/src/main/kotlin/team/noweekend/core/remote/model/login/LoginResponse.kt
+++ b/core/remote/src/main/kotlin/team/noweekend/core/remote/model/login/LoginResponse.kt
@@ -1,4 +1,4 @@
-package team.noweekend.core.remote.model
+package team.noweekend.core.remote.model.login
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable

--- a/core/remote/src/main/kotlin/team/noweekend/core/remote/model/recommend/SandwichRecommendResponse.kt
+++ b/core/remote/src/main/kotlin/team/noweekend/core/remote/model/recommend/SandwichRecommendResponse.kt
@@ -1,0 +1,12 @@
+package team.noweekend.core.remote.model.recommend
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SandwichRecommendResponse(
+    @SerialName("startDate")
+    val startDate: String,
+    @SerialName("endDate")
+    val endDate: String,
+)

--- a/core/remote/src/main/kotlin/team/noweekend/core/remote/model/user/Token.kt
+++ b/core/remote/src/main/kotlin/team/noweekend/core/remote/model/user/Token.kt
@@ -1,4 +1,4 @@
-package team.noweekend.core.remote.model
+package team.noweekend.core.remote.model.user
 
 data class Token(
     val access: String,

--- a/core/remote/src/main/kotlin/team/noweekend/core/remote/model/user/UserProfileResponse.kt
+++ b/core/remote/src/main/kotlin/team/noweekend/core/remote/model/user/UserProfileResponse.kt
@@ -1,0 +1,33 @@
+package team.noweekend.core.remote.model.user
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import team.noweekend.core.remote.model.location.UserLocationDto
+
+@Serializable
+data class UserProfileResponse(
+    @SerialName("id")
+    val userId: String,
+    @SerialName("email")
+    val userEmail: String,
+    @SerialName("name")
+    val userName: String,
+    @SerialName("gender")
+    val userGender: String,
+    @SerialName("birthDate")
+    val userBirth: String,
+    @SerialName("providerId")
+    val oAuthId: String,
+    @SerialName("providerType")
+    val oAuthType: String,
+    @SerialName("revocableToken")
+    val revocableToken: String,
+    @SerialName("role")
+    val role: String,
+    @SerialName("remainingAnnualLeave")
+    val remainingAnnualLeave: Float,
+    @SerialName("location")
+    val location: UserLocationDto,
+    @SerialName("averageTemperature")
+    val averageTemperature: Float,
+)

--- a/core/remote/src/main/kotlin/team/noweekend/core/remote/provider/TokenProvider.kt
+++ b/core/remote/src/main/kotlin/team/noweekend/core/remote/provider/TokenProvider.kt
@@ -1,7 +1,7 @@
 package team.noweekend.core.remote.provider
 
 import kotlinx.coroutines.flow.Flow
-import team.noweekend.core.remote.model.Token
+import team.noweekend.core.remote.model.user.Token
 
 interface TokenProvider {
     val tokenFlow: Flow<Token>

--- a/core/remote/src/main/kotlin/team/noweekend/core/remote/provider/TokenProviderImpl.kt
+++ b/core/remote/src/main/kotlin/team/noweekend/core/remote/provider/TokenProviderImpl.kt
@@ -4,21 +4,21 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
-import team.noweekend.core.remote.model.Token
+import team.noweekend.core.remote.model.user.Token
 import javax.inject.Inject
 
 internal class TokenProviderImpl @Inject constructor() : TokenProvider {
-    
+
     private val _tokenFlow = MutableStateFlow<Token>(Token.INITIAL_STATE)
     override val tokenFlow: StateFlow<Token> = _tokenFlow.asStateFlow()
-    
-    
+
+
     override suspend fun updateAccessToken(token: String) {
         _tokenFlow.update {
             it.copy(access = token)
         }
     }
-    
+
     override suspend fun updateRefreshToken(token: String) {
         _tokenFlow.update {
             it.copy(refresh = token)

--- a/feature/home/src/main/java/team/noweekend/feature/home/component/holiday/HolidayRecommendComponent.kt
+++ b/feature/home/src/main/java/team/noweekend/feature/home/component/holiday/HolidayRecommendComponent.kt
@@ -28,7 +28,7 @@ internal fun LazyListScope.holidayRecommend(
 }
 
 @Composable
-private fun HolidayRecommendComponent(
+internal fun HolidayRecommendComponent(
     holidays: ImmutableList<HolidayUiModel>,
     onHolidayCardClick: () -> Unit,
     modifier: Modifier = Modifier,

--- a/feature/home/src/main/java/team/noweekend/feature/home/component/popular/PopularVacationRecommendComponent.kt
+++ b/feature/home/src/main/java/team/noweekend/feature/home/component/popular/PopularVacationRecommendComponent.kt
@@ -72,10 +72,12 @@ private fun PopularVacationRecommendContent(
     popularVacations: ImmutableList<PopularVacationUiModel>,
     modifier: Modifier = Modifier,
 ) {
+    val height: Dp = if (popularVacations.size > 2) 500.dp else 250.dp
+
     LazyVerticalGrid(
         modifier = modifier
             .fillMaxWidth()
-            .height(500.dp)
+            .height(height)
             .padding(horizontal = 20.dp),
         columns = GridCells.Fixed(2),
         verticalArrangement = Arrangement.spacedBy(16.dp),

--- a/feature/home/src/main/java/team/noweekend/feature/home/component/popular/PopularVacationRecommendComponent.kt
+++ b/feature/home/src/main/java/team/noweekend/feature/home/component/popular/PopularVacationRecommendComponent.kt
@@ -1,26 +1,45 @@
 package team.noweekend.feature.home.component.popular
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.ImmutableList
-import kotlinx.collections.immutable.ImmutableMap
 import team.noweekend.core.common.android.extension.fillMaxWidthOfScreen
+import team.noweekend.core.design.system.core.component.card.NWKShortCard
 import team.noweekend.core.design.system.foundation.theme.NWKTheme
-import team.noweekend.feature.home.component.popular.carousel.PopularVacationCarousel
 import team.noweekend.feature.home.model.PopularVacationUiModel
+import team.noweekend.feature.home.model.PopularVacationUiModel.Companion.getStyledDescription
+
+internal fun LazyListScope.popularVacationRecommend(
+    popularVacations: ImmutableList<PopularVacationUiModel>,
+    modifier: Modifier = Modifier,
+) = item {
+    PopularVacationRecommendComponent(
+        popularVacations = popularVacations,
+        modifier = modifier,
+    )
+}
 
 @Composable
 internal fun PopularVacationRecommendComponent(
-    popularVacations: ImmutableMap<Int, ImmutableList<PopularVacationUiModel>>,
+    popularVacations: ImmutableList<PopularVacationUiModel>,
     modifier: Modifier = Modifier,
 ) {
     Column(
         modifier = modifier.fillMaxWidthOfScreen(),
+        horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         PopularVacationRecommendHeader()
         PopularVacationRecommendContent(
@@ -49,11 +68,27 @@ private fun PopularVacationRecommendHeader(
 }
 
 @Composable
-private fun ColumnScope.PopularVacationRecommendContent(
-    popularVacations: ImmutableMap<Int, ImmutableList<PopularVacationUiModel>>,
+private fun PopularVacationRecommendContent(
+    popularVacations: ImmutableList<PopularVacationUiModel>,
     modifier: Modifier = Modifier,
 ) {
-    PopularVacationCarousel(
-        popularVacations = popularVacations,
+    LazyVerticalGrid(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(500.dp)
+            .padding(horizontal = 20.dp),
+        columns = GridCells.Fixed(2),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+        content = {
+            items(popularVacations) {
+                NWKShortCard(
+                    date = it.displayDate,
+                    drawableResId = it.imageResourceId,
+                    description = it.vacationType.getStyledDescription(),
+                    onCardClick = {},
+                )
+            }
+        },
     )
 }

--- a/feature/home/src/main/java/team/noweekend/feature/home/component/popular/PopularVacationRecommendComponent.kt
+++ b/feature/home/src/main/java/team/noweekend/feature/home/component/popular/PopularVacationRecommendComponent.kt
@@ -2,10 +2,8 @@ package team.noweekend.feature.home.component.popular
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -14,13 +12,11 @@ import kotlinx.collections.immutable.ImmutableMap
 import team.noweekend.core.common.android.extension.fillMaxWidthOfScreen
 import team.noweekend.core.design.system.foundation.theme.NWKTheme
 import team.noweekend.feature.home.component.popular.carousel.PopularVacationCarousel
-import team.noweekend.feature.home.component.popular.chip.DateSelectableChip
 import team.noweekend.feature.home.model.PopularVacationUiModel
 
 @Composable
 internal fun PopularVacationRecommendComponent(
     popularVacations: ImmutableMap<Int, ImmutableList<PopularVacationUiModel>>,
-    onDateSelectableChipClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -29,7 +25,6 @@ internal fun PopularVacationRecommendComponent(
         PopularVacationRecommendHeader()
         PopularVacationRecommendContent(
             popularVacations = popularVacations,
-            onDateSelectableChipClick = onDateSelectableChipClick,
         )
     }
 }
@@ -56,16 +51,8 @@ private fun PopularVacationRecommendHeader(
 @Composable
 private fun ColumnScope.PopularVacationRecommendContent(
     popularVacations: ImmutableMap<Int, ImmutableList<PopularVacationUiModel>>,
-    onDateSelectableChipClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    DateSelectableChip(
-        modifier = Modifier.padding(
-            start = NWKTheme.spacing.space300,
-        ),
-        onChipClick = onDateSelectableChipClick,
-    )
-    Spacer(Modifier.size(NWKTheme.spacing.space175))
     PopularVacationCarousel(
         popularVacations = popularVacations,
     )

--- a/feature/home/src/main/java/team/noweekend/feature/home/model/HolidayUiModel.kt
+++ b/feature/home/src/main/java/team/noweekend/feature/home/model/HolidayUiModel.kt
@@ -5,6 +5,7 @@ import kotlinx.datetime.LocalDate
 import team.noweekend.core.common.kotlin.extension.now
 import team.noweekend.core.common.kotlin.extension.parseLocalDateString
 import team.noweekend.core.model.holiday.Holiday
+import team.noweekend.core.model.vacation.VacationType
 
 @Stable
 data class HolidayUiModel(
@@ -22,4 +23,10 @@ data class HolidayUiModel(
 internal fun Holiday.toUiModel() = HolidayUiModel(
     date = LocalDate.parseLocalDateString(this.date),
     holiday = this.holiday,
+)
+
+internal fun Holiday.toPopularVacation() = PopularVacationUiModel(
+    vacationType = VacationType.HOLIDAY_EXIST,
+    startLocalDate = LocalDate.parseLocalDateString(this.date),
+    endLocalDate = null,
 )

--- a/feature/home/src/main/java/team/noweekend/feature/home/model/PopularVacationUiModel.kt
+++ b/feature/home/src/main/java/team/noweekend/feature/home/model/PopularVacationUiModel.kt
@@ -9,8 +9,10 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.withStyle
 import kotlinx.datetime.LocalDate
 import team.noweekend.core.common.kotlin.extension.MONTH_DATE_WITH_DAY_OF_WEEK_KR_PATTERN
+import team.noweekend.core.common.kotlin.extension.MONTH_DATE_WITH_DAY_OF_WEEK_PATTERN
 import team.noweekend.core.common.kotlin.extension.toFormattedString
 import team.noweekend.core.design.system.foundation.theme.NWKTheme
+import team.noweekend.core.model.vacation.SandwichRecommendVacation
 import team.noweekend.core.model.vacation.VacationType
 import team.noweekend.core.resource.NWKDrawableResource
 import team.noweekend.core.resource.NWKStringResource
@@ -37,9 +39,9 @@ data class PopularVacationUiModel(
 
     private fun formatDisplayDate(startLocalDate: LocalDate, endLocalDate: LocalDate?): String {
         val startDisplayDate: String =
-            startLocalDate.toFormattedString(LocalDate.MONTH_DATE_WITH_DAY_OF_WEEK_KR_PATTERN)
+            startLocalDate.toFormattedString(LocalDate.MONTH_DATE_WITH_DAY_OF_WEEK_PATTERN)
         val endDisplayDate: String? =
-            endLocalDate?.toFormattedString(LocalDate.MONTH_DATE_WITH_DAY_OF_WEEK_KR_PATTERN)
+            endLocalDate?.toFormattedString(LocalDate.MONTH_DATE_WITH_DAY_OF_WEEK_PATTERN)
 
         return if (endDisplayDate.isNullOrEmpty().not()) {
             "$startDisplayDate ~ $endDisplayDate"
@@ -111,3 +113,9 @@ data class PopularVacationUiModel(
         }
     }
 }
+
+internal fun SandwichRecommendVacation.toPopularVacation() = PopularVacationUiModel(
+    vacationType = VacationType.INCLUDE_MONDAY,
+    startLocalDate = LocalDate.parse(this.startDate),
+    endLocalDate = LocalDate.parse(this.endDate),
+)

--- a/feature/home/src/main/java/team/noweekend/feature/home/model/PopularVacationUiModel.kt
+++ b/feature/home/src/main/java/team/noweekend/feature/home/model/PopularVacationUiModel.kt
@@ -8,7 +8,6 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.withStyle
 import kotlinx.datetime.LocalDate
-import team.noweekend.core.common.kotlin.extension.MONTH_DATE_WITH_DAY_OF_WEEK_KR_PATTERN
 import team.noweekend.core.common.kotlin.extension.MONTH_DATE_WITH_DAY_OF_WEEK_PATTERN
 import team.noweekend.core.common.kotlin.extension.toFormattedString
 import team.noweekend.core.design.system.foundation.theme.NWKTheme

--- a/feature/home/src/main/java/team/noweekend/feature/home/mvi/HomeUiState.kt
+++ b/feature/home/src/main/java/team/noweekend/feature/home/mvi/HomeUiState.kt
@@ -14,7 +14,6 @@ data class HomeUiState(
     val isLoading: Boolean,
     val createVacationStatus: CreateVacationStatus,
     val remainedHolidays: ImmutableList<HolidayUiModel>,
-    val monthlyHolidays: ImmutableList<HolidayUiModel>,
     val weatherRecommendVacations: ImmutableList<MonthlyVacationRecommendUiModel>,
 ) : UiState {
 
@@ -23,7 +22,6 @@ data class HomeUiState(
             isLoading = false,
             createVacationStatus = CreateVacationStatus.Default(6),
             remainedHolidays = persistentListOf(),
-            monthlyHolidays = persistentListOf(),
             weatherRecommendVacations = persistentListOf(),
         )
     }

--- a/feature/home/src/main/java/team/noweekend/feature/home/mvi/HomeUiState.kt
+++ b/feature/home/src/main/java/team/noweekend/feature/home/mvi/HomeUiState.kt
@@ -8,6 +8,7 @@ import team.noweekend.core.resource.NWKDrawableResource
 import team.noweekend.core.resource.NWKStringResource
 import team.noweekend.feature.home.model.HolidayUiModel
 import team.noweekend.feature.home.model.MonthlyVacationRecommendUiModel
+import team.noweekend.feature.home.model.PopularVacationUiModel
 
 @Stable
 data class HomeUiState(
@@ -15,6 +16,7 @@ data class HomeUiState(
     val createVacationStatus: CreateVacationStatus,
     val remainedHolidays: ImmutableList<HolidayUiModel>,
     val weatherRecommendVacations: ImmutableList<MonthlyVacationRecommendUiModel>,
+    val popularVacations: ImmutableList<PopularVacationUiModel>,
 ) : UiState {
 
     companion object {
@@ -23,6 +25,7 @@ data class HomeUiState(
             createVacationStatus = CreateVacationStatus.Default(6),
             remainedHolidays = persistentListOf(),
             weatherRecommendVacations = persistentListOf(),
+            popularVacations = persistentListOf(),
         )
     }
 }

--- a/feature/home/src/main/java/team/noweekend/feature/home/mvi/HomeViewModel.kt
+++ b/feature/home/src/main/java/team/noweekend/feature/home/mvi/HomeViewModel.kt
@@ -105,7 +105,6 @@ class HomeViewModel @Inject constructor(
             }
     }
 
-
     private fun saveUserLocation() = execute {
         userLocationUseCase.saveLocation()
             .onSuccess {

--- a/feature/home/src/main/java/team/noweekend/feature/home/mvi/HomeViewModel.kt
+++ b/feature/home/src/main/java/team/noweekend/feature/home/mvi/HomeViewModel.kt
@@ -4,13 +4,16 @@ import android.util.Log
 import androidx.lifecycle.SavedStateHandle
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import team.noweekend.core.common.android.base.MVIViewModel
 import team.noweekend.core.domain.usecase.GetHolidayUseCase
+import team.noweekend.core.domain.usecase.GetSandwichRecommendVacationUseCase
 import team.noweekend.core.domain.usecase.GetWeatherRecommendVacationUseCase
 import team.noweekend.core.domain.usecase.UserLocationUseCase
 import team.noweekend.feature.home.model.HolidayUiModel
 import team.noweekend.feature.home.model.MonthlyVacationRecommendUiModel
+import team.noweekend.feature.home.model.toPopularVacation
 import team.noweekend.feature.home.model.toUiModel
 import javax.inject.Inject
 
@@ -20,10 +23,12 @@ class HomeViewModel @Inject constructor(
     private val getHolidayUseCase: GetHolidayUseCase,
     private val getWeatherRecommendVacationUseCase: GetWeatherRecommendVacationUseCase,
     private val userLocationUseCase: UserLocationUseCase,
+    private val getSandwichRecommendVacationUseCase: GetSandwichRecommendVacationUseCase,
 ) : MVIViewModel<HomeIntent, HomeSideEffect, HomeUiState>(
     savedStateHandle = savedStateHandle,
 ) {
     init {
+        getPopularRecommendVacations()
         getRemainedHolidays()
         saveUserLocation()
     }
@@ -50,6 +55,20 @@ class HomeViewModel @Inject constructor(
         }
     }
 
+
+    private fun getPopularRecommendVacations() = execute {
+        val remainedHolidaysDeferred = async { getHolidayUseCase.getRemainedHolidays() }
+        val sandwichRecommendationsDeferred = async { getSandwichRecommendVacationUseCase.invoke() }
+        val userProfileDeferred = async { }
+
+        val remainedRecentHolidays = remainedHolidaysDeferred.await().getOrNull()?.firstOrNull()?.toPopularVacation()
+        val sandwichRecommendations = sandwichRecommendationsDeferred.await().getOrNull()?.toPopularVacation()
+
+        reduce {
+            copy(popularVacations = listOfNotNull(remainedRecentHolidays, sandwichRecommendations).toImmutableList())
+        }
+    }
+
     private fun getRemainedHolidays() = execute {
         getHolidayUseCase.getRemainedHolidays()
             .onSuccess { remoteHolidays ->
@@ -60,6 +79,7 @@ class HomeViewModel @Inject constructor(
                 Log.d("logtag", "$exception")
             }
     }
+
 
     private fun saveUserLocation() = execute {
         userLocationUseCase.saveLocation()

--- a/feature/home/src/main/java/team/noweekend/feature/home/mvi/HomeViewModel.kt
+++ b/feature/home/src/main/java/team/noweekend/feature/home/mvi/HomeViewModel.kt
@@ -6,13 +6,18 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
+import kotlinx.datetime.LocalDate
 import team.noweekend.core.common.android.base.MVIViewModel
+import team.noweekend.core.common.kotlin.extension.parseLocalDateString
 import team.noweekend.core.domain.usecase.GetHolidayUseCase
 import team.noweekend.core.domain.usecase.GetSandwichRecommendVacationUseCase
+import team.noweekend.core.domain.usecase.GetUserProfileUseCase
 import team.noweekend.core.domain.usecase.GetWeatherRecommendVacationUseCase
 import team.noweekend.core.domain.usecase.UserLocationUseCase
+import team.noweekend.core.model.vacation.VacationType
 import team.noweekend.feature.home.model.HolidayUiModel
 import team.noweekend.feature.home.model.MonthlyVacationRecommendUiModel
+import team.noweekend.feature.home.model.PopularVacationUiModel
 import team.noweekend.feature.home.model.toPopularVacation
 import team.noweekend.feature.home.model.toUiModel
 import javax.inject.Inject
@@ -24,6 +29,7 @@ class HomeViewModel @Inject constructor(
     private val getWeatherRecommendVacationUseCase: GetWeatherRecommendVacationUseCase,
     private val userLocationUseCase: UserLocationUseCase,
     private val getSandwichRecommendVacationUseCase: GetSandwichRecommendVacationUseCase,
+    private val getUserProfileUseCase: GetUserProfileUseCase,
 ) : MVIViewModel<HomeIntent, HomeSideEffect, HomeUiState>(
     savedStateHandle = savedStateHandle,
 ) {
@@ -55,17 +61,36 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-
     private fun getPopularRecommendVacations() = execute {
         val remainedHolidaysDeferred = async { getHolidayUseCase.getRemainedHolidays() }
         val sandwichRecommendationsDeferred = async { getSandwichRecommendVacationUseCase.invoke() }
-        val userProfileDeferred = async { }
+        val userProfileDeferred = async { getUserProfileUseCase.invoke() }
 
-        val remainedRecentHolidays = remainedHolidaysDeferred.await().getOrNull()?.firstOrNull()?.toPopularVacation()
-        val sandwichRecommendations = sandwichRecommendationsDeferred.await().getOrNull()?.toPopularVacation()
+        val remainedRecentHolidays = remainedHolidaysDeferred.await()
+            .getOrNull()?.firstOrNull()?.toPopularVacation()
+
+        val sandwichRecommendations = sandwichRecommendationsDeferred.await()
+            .getOrNull()?.toPopularVacation()
+
+        val userBirth = userProfileDeferred.await()
+            .getOrNull()?.userBirth
+
+        val userBirthVacation = userBirth?.let { birth ->
+            PopularVacationUiModel(
+                vacationType = VacationType.BIRTHDAY_EXIST,
+                startLocalDate = LocalDate.parseLocalDateString(birth),
+                endLocalDate = null,
+            )
+        }
 
         reduce {
-            copy(popularVacations = listOfNotNull(remainedRecentHolidays, sandwichRecommendations).toImmutableList())
+            copy(
+                popularVacations = listOfNotNull(
+                    remainedRecentHolidays,
+                    sandwichRecommendations,
+                    userBirthVacation,
+                ).toImmutableList(),
+            )
         }
     }
 

--- a/feature/home/src/main/java/team/noweekend/feature/home/mvi/HomeViewModel.kt
+++ b/feature/home/src/main/java/team/noweekend/feature/home/mvi/HomeViewModel.kt
@@ -5,9 +5,7 @@ import androidx.lifecycle.SavedStateHandle
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.delay
-import kotlinx.datetime.LocalDate
 import team.noweekend.core.common.android.base.MVIViewModel
-import team.noweekend.core.common.kotlin.extension.now
 import team.noweekend.core.domain.usecase.GetHolidayUseCase
 import team.noweekend.core.domain.usecase.GetWeatherRecommendVacationUseCase
 import team.noweekend.core.domain.usecase.UserLocationUseCase
@@ -27,7 +25,6 @@ class HomeViewModel @Inject constructor(
 ) {
     init {
         getRemainedHolidays()
-        getHolidays()
         saveUserLocation()
     }
 
@@ -51,17 +48,6 @@ class HomeViewModel @Inject constructor(
 
             else -> {}
         }
-    }
-
-    private fun getHolidays(requestDate: LocalDate = LocalDate.now()) = execute {
-        getHolidayUseCase.getMonthlyHolidays(requestDate)
-            .onSuccess { remoteHolidays ->
-                val holidays: List<HolidayUiModel> = remoteHolidays.map { it.toUiModel() }
-                reduce { copy(monthlyHolidays = holidays.toImmutableList()) }
-            }
-            .onFailure { exception ->
-                Log.d("logtag", "$exception")
-            }
     }
 
     private fun getRemainedHolidays() = execute {

--- a/feature/home/src/main/java/team/noweekend/feature/home/screen/HomeScreen.kt
+++ b/feature/home/src/main/java/team/noweekend/feature/home/screen/HomeScreen.kt
@@ -57,7 +57,6 @@ internal fun HomeScreen(
         itemSpacer(40.dp)
         item {
             PopularVacationRecommendComponent(
-                onDateSelectableChipClick = {},
                 popularVacations = persistentMapOf(
                     Pair(
                         0,

--- a/feature/home/src/main/java/team/noweekend/feature/home/screen/HomeScreen.kt
+++ b/feature/home/src/main/java/team/noweekend/feature/home/screen/HomeScreen.kt
@@ -10,18 +10,15 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import kotlinx.collections.immutable.persistentListOf
 import kotlinx.datetime.LocalDate
 import team.noweekend.core.common.android.extension.fillMaxWidthOfScreen
 import team.noweekend.core.common.kotlin.extension.now
 import team.noweekend.core.design.system.foundation.theme.NWKTheme
-import team.noweekend.core.model.vacation.VacationType
 import team.noweekend.feature.home.component.common.spacer.itemSpacer
 import team.noweekend.feature.home.component.holiday.holidayRecommend
 import team.noweekend.feature.home.component.popular.popularVacationRecommend
 import team.noweekend.feature.home.component.recommend.monthly.monthlyVacationRecommendComponent
 import team.noweekend.feature.home.component.vacation.createVacation
-import team.noweekend.feature.home.model.PopularVacationUiModel
 import team.noweekend.feature.home.mvi.HomeUiState
 
 @Composable

--- a/feature/home/src/main/java/team/noweekend/feature/home/screen/HomeScreen.kt
+++ b/feature/home/src/main/java/team/noweekend/feature/home/screen/HomeScreen.kt
@@ -55,30 +55,8 @@ internal fun HomeScreen(
         )
         itemSpacer(40.dp)
         popularVacationRecommend(
-            popularVacations = persistentListOf(
-                PopularVacationUiModel(
-                    vacationType = VacationType.HOLIDAY_EXIST,
-                    startLocalDate = LocalDate.now(),
-                    endLocalDate = LocalDate.now(),
-                ),
-                PopularVacationUiModel(
-                    vacationType = VacationType.BIRTHDAY_EXIST,
-                    startLocalDate = LocalDate.now(),
-                    endLocalDate = LocalDate.now(),
-                ),
-                PopularVacationUiModel(
-                    vacationType = VacationType.INCLUDE_MONDAY,
-                    startLocalDate = LocalDate.now(),
-                    endLocalDate = LocalDate.now(),
-                ),
-                PopularVacationUiModel(
-                    vacationType = VacationType.INCLUDE_MONDAY,
-                    startLocalDate = LocalDate.now(),
-                    endLocalDate = LocalDate.now(),
-                ),
-            ),
+            popularVacations = uiState.popularVacations,
         )
-//        itemSpacer(72.dp)
     }
 }
 

--- a/feature/home/src/main/java/team/noweekend/feature/home/screen/HomeScreen.kt
+++ b/feature/home/src/main/java/team/noweekend/feature/home/screen/HomeScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.persistentMapOf
 import kotlinx.datetime.LocalDate
 import team.noweekend.core.common.android.extension.fillMaxWidthOfScreen
 import team.noweekend.core.common.kotlin.extension.now
@@ -19,7 +18,7 @@ import team.noweekend.core.design.system.foundation.theme.NWKTheme
 import team.noweekend.core.model.vacation.VacationType
 import team.noweekend.feature.home.component.common.spacer.itemSpacer
 import team.noweekend.feature.home.component.holiday.holidayRecommend
-import team.noweekend.feature.home.component.popular.PopularVacationRecommendComponent
+import team.noweekend.feature.home.component.popular.popularVacationRecommend
 import team.noweekend.feature.home.component.recommend.monthly.monthlyVacationRecommendComponent
 import team.noweekend.feature.home.component.vacation.createVacation
 import team.noweekend.feature.home.model.PopularVacationUiModel
@@ -55,88 +54,31 @@ internal fun HomeScreen(
             recommends = uiState.weatherRecommendVacations,
         )
         itemSpacer(40.dp)
-        item {
-            PopularVacationRecommendComponent(
-                popularVacations = persistentMapOf(
-                    Pair(
-                        0,
-                        persistentListOf(
-                            PopularVacationUiModel(
-                                vacationType = VacationType.HOLIDAY_EXIST,
-                                startLocalDate = LocalDate.now(),
-                                endLocalDate = LocalDate.now(),
-                            ),
-                            PopularVacationUiModel(
-                                vacationType = VacationType.BIRTHDAY_EXIST,
-                                startLocalDate = LocalDate.now(),
-                                endLocalDate = LocalDate.now(),
-                            ),
-                            PopularVacationUiModel(
-                                vacationType = VacationType.INCLUDE_MONDAY,
-                                startLocalDate = LocalDate.now(),
-                                endLocalDate = LocalDate.now(),
-                            ),
-                            PopularVacationUiModel(
-                                vacationType = VacationType.INCLUDE_MONDAY,
-                                startLocalDate = LocalDate.now(),
-                                endLocalDate = LocalDate.now(),
-                            ),
-                        ),
-                    ),
-                    Pair(
-                        1,
-                        persistentListOf(
-                            PopularVacationUiModel(
-                                vacationType = VacationType.HOLIDAY_EXIST,
-                                startLocalDate = LocalDate.now(),
-                                endLocalDate = LocalDate.now(),
-                            ),
-                            PopularVacationUiModel(
-                                vacationType = VacationType.BIRTHDAY_EXIST,
-                                startLocalDate = LocalDate.now(),
-                                endLocalDate = LocalDate.now(),
-                            ),
-                            PopularVacationUiModel(
-                                vacationType = VacationType.INCLUDE_MONDAY,
-                                startLocalDate = LocalDate.now(),
-                                endLocalDate = LocalDate.now(),
-                            ),
-                            PopularVacationUiModel(
-                                vacationType = VacationType.INCLUDE_MONDAY,
-                                startLocalDate = LocalDate.now(),
-                                endLocalDate = LocalDate.now(),
-                            ),
-                        ),
-                    ),
-                    Pair(
-                        2,
-                        persistentListOf(
-                            PopularVacationUiModel(
-                                vacationType = VacationType.HOLIDAY_EXIST,
-                                startLocalDate = LocalDate.now(),
-                                endLocalDate = LocalDate.now(),
-                            ),
-                            PopularVacationUiModel(
-                                vacationType = VacationType.BIRTHDAY_EXIST,
-                                startLocalDate = LocalDate.now(),
-                                endLocalDate = LocalDate.now(),
-                            ),
-                            PopularVacationUiModel(
-                                vacationType = VacationType.INCLUDE_MONDAY,
-                                startLocalDate = LocalDate.now(),
-                                endLocalDate = LocalDate.now(),
-                            ),
-                            PopularVacationUiModel(
-                                vacationType = VacationType.INCLUDE_MONDAY,
-                                startLocalDate = LocalDate.now(),
-                                endLocalDate = LocalDate.now(),
-                            ),
-                        ),
-                    ),
+        popularVacationRecommend(
+            popularVacations = persistentListOf(
+                PopularVacationUiModel(
+                    vacationType = VacationType.HOLIDAY_EXIST,
+                    startLocalDate = LocalDate.now(),
+                    endLocalDate = LocalDate.now(),
                 ),
-            )
-        }
-        itemSpacer(72.dp)
+                PopularVacationUiModel(
+                    vacationType = VacationType.BIRTHDAY_EXIST,
+                    startLocalDate = LocalDate.now(),
+                    endLocalDate = LocalDate.now(),
+                ),
+                PopularVacationUiModel(
+                    vacationType = VacationType.INCLUDE_MONDAY,
+                    startLocalDate = LocalDate.now(),
+                    endLocalDate = LocalDate.now(),
+                ),
+                PopularVacationUiModel(
+                    vacationType = VacationType.INCLUDE_MONDAY,
+                    startLocalDate = LocalDate.now(),
+                    endLocalDate = LocalDate.now(),
+                ),
+            ),
+        )
+//        itemSpacer(72.dp)
     }
 }
 


### PR DESCRIPTION
### What is this PR (Required)
- **Issue Number** : close #124 
- **Figma :**
- 기타 관련 문서 :

### Changes (Required)
- 잔여 공휴일, 샌드위치, 사용자 프로필 API 추가
- 3가지 API 조합한 UI 노출
- 기존 인기 휴가 UI 변경 (Carousel -> VerticalGrid)

### Review Point (Required)
- 세 API 병렬 호출 했습니다
- 안내려오면 안내려오는대로 스킵해서 리스트 구성해서 뿌려요
- LazyVerticalGrid는 일단 고정 높이값을 박아 넣었습니다... 굉장히 짜치는 방식으로 넣어놨는데 눈감아봐 일단
- 스크린샷에는 생일 휴가가 없는데 이거 profileAPI 조회 해보니까 임시토큰으로 조회했어서 온보딩 스킵된 토큰이라 에러로 내려오긴 합니다
- 확인해봐야해요

### Screenshot
| 기능 | 스크린샷 |
| --- | --- |
| GIF | <img src="https://github.com/user-attachments/assets/767d7802-71a4-4b06-9a39-a800694ac097" width="300" /> |

### 관련 Reference 자료
-