### PR TITLE
[#131] 디테일 화면, 할일 완료 추가

### DIFF
--- a/core/common-ui/src/main/java/team/noweekend/core/common/ui/calendar/component/CalendarTodoBoard.kt
+++ b/core/common-ui/src/main/java/team/noweekend/core/common/ui/calendar/component/CalendarTodoBoard.kt
@@ -74,21 +74,21 @@ private fun PreviewTodoCalendarBoard() {
                     description = "description",
                     isDone = true,
                     todoType = TodoType.Etc(),
-                    id = "1"
+                    id = "1",
                 ),
                 Todo(
                     title = "title",
                     description = "description",
                     isDone = false,
                     todoType = TodoType.Personal(),
-                    id = "2"
+                    id = "2",
                 ),
                 Todo(
                     title = "title",
                     description = "description",
                     isDone = true,
                     todoType = TodoType.Company(),
-                    id = "3"
+                    id = "3",
                 ),
             ),
         )

--- a/core/common-ui/src/main/java/team/noweekend/core/common/ui/calendar/component/CalendarTodoBoard.kt
+++ b/core/common-ui/src/main/java/team/noweekend/core/common/ui/calendar/component/CalendarTodoBoard.kt
@@ -74,18 +74,21 @@ private fun PreviewTodoCalendarBoard() {
                     description = "description",
                     isDone = true,
                     todoType = TodoType.Etc(),
+                    id = "1"
                 ),
                 Todo(
                     title = "title",
                     description = "description",
                     isDone = false,
                     todoType = TodoType.Personal(),
+                    id = "2"
                 ),
                 Todo(
                     title = "title",
                     description = "description",
                     isDone = true,
                     todoType = TodoType.Company(),
+                    id = "3"
                 ),
             ),
         )

--- a/core/common-ui/src/main/java/team/noweekend/core/common/ui/calendar/component/CalendarTodoList.kt
+++ b/core/common-ui/src/main/java/team/noweekend/core/common/ui/calendar/component/CalendarTodoList.kt
@@ -60,21 +60,21 @@ private fun PreviewCalendarTodoList() {
                     description = "description",
                     isDone = false,
                     todoType = TodoType.Etc(),
-                    id = "0"
+                    id = "0",
                 ),
                 Todo(
                     title = "title",
                     description = "description",
                     isDone = false,
                     todoType = TodoType.Personal(),
-                    id = "0"
+                    id = "0",
                 ),
                 Todo(
                     title = "title",
                     description = "description",
                     isDone = false,
                     todoType = TodoType.Company(),
-                    id = "0"
+                    id = "0",
                 ),
             ),
             onClickCheckBox = {},

--- a/core/common-ui/src/main/java/team/noweekend/core/common/ui/calendar/component/CalendarTodoList.kt
+++ b/core/common-ui/src/main/java/team/noweekend/core/common/ui/calendar/component/CalendarTodoList.kt
@@ -60,18 +60,21 @@ private fun PreviewCalendarTodoList() {
                     description = "description",
                     isDone = false,
                     todoType = TodoType.Etc(),
+                    id = "0"
                 ),
                 Todo(
                     title = "title",
                     description = "description",
                     isDone = false,
                     todoType = TodoType.Personal(),
+                    id = "0"
                 ),
                 Todo(
                     title = "title",
                     description = "description",
                     isDone = false,
                     todoType = TodoType.Company(),
+                    id = "0"
                 ),
             ),
             onClickCheckBox = {},

--- a/core/common-ui/src/main/java/team/noweekend/core/common/ui/todo/TodoRecordContent.kt
+++ b/core/common-ui/src/main/java/team/noweekend/core/common/ui/todo/TodoRecordContent.kt
@@ -84,7 +84,7 @@ private fun PreviewTodoRecordContent() {
                 title = "회의 참석",
                 description = "10:00 ~ 11:00",
                 todoType = TodoType.Company(),
-                id = "0"
+                id = "0",
             ),
         )
     }

--- a/core/common-ui/src/main/java/team/noweekend/core/common/ui/todo/TodoRecordContent.kt
+++ b/core/common-ui/src/main/java/team/noweekend/core/common/ui/todo/TodoRecordContent.kt
@@ -84,6 +84,7 @@ private fun PreviewTodoRecordContent() {
                 title = "회의 참석",
                 description = "10:00 ~ 11:00",
                 todoType = TodoType.Company(),
+                id = "0"
             ),
         )
     }

--- a/core/common-ui/src/main/java/team/noweekend/core/common/ui/todo/model/Todo.kt
+++ b/core/common-ui/src/main/java/team/noweekend/core/common/ui/todo/model/Todo.kt
@@ -12,6 +12,7 @@ import team.noweekend.core.resource.NWKStringResource
 
 @Immutable
 data class Todo(
+    val id: String,
     val title: String,
     val description: String,
     val todoType: TodoType,
@@ -21,18 +22,21 @@ data class Todo(
 
         val previewDummy: ImmutableList<Todo> = persistentListOf<Todo>(
             Todo(
+                id = "1",
                 title = "축구하기",
                 description = "1",
                 todoType = TodoType.Personal(),
                 isDone = false,
             ),
             Todo(
+                id = "2",
                 title = "출근하기",
                 description = "2",
                 todoType = TodoType.Company(),
                 isDone = false,
             ),
             Todo(
+                id = "3",
                 title = "기타등등",
                 description = "1",
                 todoType = TodoType.Etc(),

--- a/core/common-ui/src/main/java/team/noweekend/core/common/ui/todo/preview/PreviewTodoRecordParameterProvider.kt
+++ b/core/common-ui/src/main/java/team/noweekend/core/common/ui/todo/preview/PreviewTodoRecordParameterProvider.kt
@@ -14,28 +14,28 @@ internal class PreviewTodoRecordParameterProvider : PreviewParameterProvider<Tod
                 description = "오전 9시 30분까지 출근하기",
                 isDone = true,
                 todoType = TodoType.Company(),
-                id = "0"
+                id = "0",
             ),
             Todo(
                 title = "친구 약속",
                 description = "밥먹기",
                 isDone = true,
                 todoType = TodoType.Personal(),
-                id = "0"
+                id = "0",
             ),
             Todo(
                 title = "여행",
                 description = "제주도 여행",
                 isDone = false,
                 todoType = TodoType.AnnualLeave(),
-                id = "0"
+                id = "0",
             ),
             Todo(
                 title = "집콕",
                 description = "집에서 쉬기",
                 isDone = false,
                 todoType = TodoType.Etc(),
-                id = "0"
+                id = "0",
             ),
         )
 }

--- a/core/common-ui/src/main/java/team/noweekend/core/common/ui/todo/preview/PreviewTodoRecordParameterProvider.kt
+++ b/core/common-ui/src/main/java/team/noweekend/core/common/ui/todo/preview/PreviewTodoRecordParameterProvider.kt
@@ -14,24 +14,28 @@ internal class PreviewTodoRecordParameterProvider : PreviewParameterProvider<Tod
                 description = "오전 9시 30분까지 출근하기",
                 isDone = true,
                 todoType = TodoType.Company(),
+                id = "0"
             ),
             Todo(
                 title = "친구 약속",
                 description = "밥먹기",
                 isDone = true,
                 todoType = TodoType.Personal(),
+                id = "0"
             ),
             Todo(
                 title = "여행",
                 description = "제주도 여행",
                 isDone = false,
                 todoType = TodoType.AnnualLeave(),
+                id = "0"
             ),
             Todo(
                 title = "집콕",
                 description = "집에서 쉬기",
                 isDone = false,
                 todoType = TodoType.Etc(),
+                id = "0"
             ),
         )
 }

--- a/core/data/src/main/java/team/noweekend/data/mapper/ScheduleMapper.kt
+++ b/core/data/src/main/java/team/noweekend/data/mapper/ScheduleMapper.kt
@@ -17,7 +17,7 @@ fun GetScheduleResponse.toDomain(): DateWithSchedules {
     )
 }
 
-fun ScheduleModel.toSchedule() : Schedule{
+fun ScheduleModel.toSchedule(): Schedule {
     return Schedule(
         id = this.id,
         title = this.title,

--- a/core/data/src/main/java/team/noweekend/data/mapper/ScheduleMapper.kt
+++ b/core/data/src/main/java/team/noweekend/data/mapper/ScheduleMapper.kt
@@ -4,6 +4,7 @@ import team.noweekend.core.model.alarm.AlarmOption
 import team.noweekend.core.model.schedule.DateWithSchedules
 import team.noweekend.core.model.schedule.Schedule
 import team.noweekend.core.model.schedule.ScheduleCategory
+import team.noweekend.core.remote.model.schedule.common.ScheduleModel
 import team.noweekend.core.remote.model.schedule.response.GetScheduleResponse
 
 fun GetScheduleResponse.toDomain(): DateWithSchedules {
@@ -11,17 +12,21 @@ fun GetScheduleResponse.toDomain(): DateWithSchedules {
         date = this.date,
         dailyTemperature = this.dailyTemperature,
         schedules = this.schedules.map { scheduleModel ->
-            Schedule(
-                id = scheduleModel.id,
-                title = scheduleModel.title,
-                startTime = scheduleModel.startTime,
-                endTime = scheduleModel.endTime,
-                category = ScheduleCategory.valueOf(scheduleModel.category),
-                temperature = scheduleModel.temperature,
-                allDay = scheduleModel.allDay,
-                completed = scheduleModel.completed,
-                alarmOption = AlarmOption.valueOf(scheduleModel.alarmOption),
-            )
+            scheduleModel.toSchedule()
         },
+    )
+}
+
+fun ScheduleModel.toSchedule() : Schedule{
+    return Schedule(
+        id = this.id,
+        title = this.title,
+        startTime = this.startTime,
+        endTime = this.endTime,
+        category = ScheduleCategory.valueOf(this.category),
+        temperature = this.temperature,
+        allDay = this.allDay,
+        completed = this.completed,
+        alarmOption = AlarmOption.valueOf(this.alarmOption),
     )
 }

--- a/core/data/src/main/java/team/noweekend/data/repository/ScheduleRepositoryImpl.kt
+++ b/core/data/src/main/java/team/noweekend/data/repository/ScheduleRepositoryImpl.kt
@@ -2,8 +2,10 @@ package team.noweekend.data.repository
 
 import team.noweekend.core.domain.repository.ScheduleRepository
 import team.noweekend.core.model.schedule.DateWithSchedules
+import team.noweekend.core.model.schedule.Schedule
 import team.noweekend.core.remote.api.schedule.ScheduleApi
 import team.noweekend.data.mapper.toDomain
+import team.noweekend.data.mapper.toSchedule
 import javax.inject.Inject
 
 internal class ScheduleRepositoryImpl @Inject constructor(
@@ -15,5 +17,13 @@ internal class ScheduleRepositoryImpl @Inject constructor(
             startDate = startDate,
             endDate = endDate,
         ).map { response -> response.toDomain() }
+    }
+
+
+    override suspend fun changeCompleteSchedule(id: String, isComplete: Boolean): Schedule {
+        return scheduleApi.changeCompleteSchedule(
+            id = id,
+            isComplete = isComplete,
+        ).toSchedule()
     }
 }

--- a/core/data/src/main/java/team/noweekend/data/repository/ScheduleRepositoryImpl.kt
+++ b/core/data/src/main/java/team/noweekend/data/repository/ScheduleRepositoryImpl.kt
@@ -19,7 +19,6 @@ internal class ScheduleRepositoryImpl @Inject constructor(
         ).map { response -> response.toDomain() }
     }
 
-
     override suspend fun changeCompleteSchedule(id: String, isComplete: Boolean): Schedule {
         return scheduleApi.changeCompleteSchedule(
             id = id,

--- a/core/domain/src/main/java/team/noweekend/core/domain/repository/ScheduleRepository.kt
+++ b/core/domain/src/main/java/team/noweekend/core/domain/repository/ScheduleRepository.kt
@@ -11,6 +11,6 @@ interface ScheduleRepository {
 
     suspend fun changeCompleteSchedule(
         id: String,
-        isComplete: Boolean
-    ) : Schedule
+        isComplete: Boolean,
+    ): Schedule
 }

--- a/core/domain/src/main/java/team/noweekend/core/domain/repository/ScheduleRepository.kt
+++ b/core/domain/src/main/java/team/noweekend/core/domain/repository/ScheduleRepository.kt
@@ -1,10 +1,16 @@
 package team.noweekend.core.domain.repository
 
 import team.noweekend.core.model.schedule.DateWithSchedules
+import team.noweekend.core.model.schedule.Schedule
 
 interface ScheduleRepository {
     suspend fun getSchedule(
         startDate: String,
         endDate: String,
     ): List<DateWithSchedules>
+
+    suspend fun changeCompleteSchedule(
+        id: String,
+        isComplete: Boolean
+    ) : Schedule
 }

--- a/core/domain/src/main/java/team/noweekend/core/domain/usecase/CalendarDataProviderUseCase.kt
+++ b/core/domain/src/main/java/team/noweekend/core/domain/usecase/CalendarDataProviderUseCase.kt
@@ -301,7 +301,6 @@ class CalendarDataProviderUseCase @Inject constructor(
     }
 
     fun updateMonthsDataWithSchedule(schedule: Schedule) {
-
         _monthData.update { weeksDataMap ->
             weeksDataMap.mapValues { entry ->
                 entry.value.copy(
@@ -315,7 +314,7 @@ class CalendarDataProviderUseCase @Inject constructor(
                             dateOfWeek.copy(
                                 scheduleList = updateScheduleList,
                                 imageType = getImageType(
-                                    temperature = updateScheduleList.filter{it.completed }.sumOf { it.temperature },
+                                    temperature = updateScheduleList.filter { it.completed }.sumOf { it.temperature },
                                     isFuture = dateOfWeek.localDate < currentLocalDate,
                                     hasRest = updateScheduleList.any { it.category == ScheduleCategory.LEAVE },
                                 ),

--- a/core/domain/src/main/java/team/noweekend/core/domain/usecase/CalendarDataProviderUseCase.kt
+++ b/core/domain/src/main/java/team/noweekend/core/domain/usecase/CalendarDataProviderUseCase.kt
@@ -11,6 +11,7 @@ import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.DayOfWeek
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.plus
+import team.noweekend.core.common.kotlin.extension.CalendarUtils.currentLocalDate
 import team.noweekend.core.common.kotlin.extension.CalendarUtils.firstDayOfMonth
 import team.noweekend.core.common.kotlin.extension.CalendarUtils.lastDayOfMonth
 import team.noweekend.core.common.kotlin.extension.CalendarUtils.minusMonths
@@ -28,9 +29,12 @@ import team.noweekend.core.domain.repository.ScheduleRepository
 import team.noweekend.core.model.calendar.DateOfWeek
 import team.noweekend.core.model.calendar.WeeksData
 import team.noweekend.core.model.calendar.getImageType
+import team.noweekend.core.model.schedule.Schedule
 import team.noweekend.core.model.schedule.ScheduleCategory
 import javax.inject.Inject
+import javax.inject.Singleton
 
+@Singleton
 class CalendarDataProviderUseCase @Inject constructor(
     private val scheduleRepository: ScheduleRepository,
 ) {
@@ -277,6 +281,51 @@ class CalendarDataProviderUseCase @Inject constructor(
 
     fun getWeeksData(page: Int): WeeksData? = _weeksData.value[page]
     fun getMonthData(page: Int): WeeksData? = _monthData.value[page]
+
+    fun updateWeeksDataWithSchedule(schedule: Schedule) {
+        _weeksData.update { weeksDataMap ->
+            weeksDataMap.mapValues { entry ->
+                entry.value.copy(
+                    dateOfWeeks = entry.value.dateOfWeeks.map { dateOfWeekList ->
+                        dateOfWeekList.map { dateOfWeek ->
+                            dateOfWeek.copy(
+                                scheduleList = dateOfWeek.scheduleList.map { innerSchedule ->
+                                    if (schedule.id == innerSchedule.id) schedule else innerSchedule
+                                },
+                            )
+                        }
+                    },
+                )
+            }
+        }
+    }
+
+    fun updateMonthsDataWithSchedule(schedule: Schedule) {
+
+        _monthData.update { weeksDataMap ->
+            weeksDataMap.mapValues { entry ->
+                entry.value.copy(
+                    dateOfWeeks = entry.value.dateOfWeeks.map { dateOfWeekList ->
+                        dateOfWeekList.map { dateOfWeek ->
+
+                            val updateScheduleList = dateOfWeek.scheduleList.map { innerSchedule ->
+                                if (schedule.id == innerSchedule.id) schedule else innerSchedule
+                            }
+
+                            dateOfWeek.copy(
+                                scheduleList = updateScheduleList,
+                                imageType = getImageType(
+                                    temperature = updateScheduleList.filter{it.completed }.sumOf { it.temperature },
+                                    isFuture = dateOfWeek.localDate < currentLocalDate,
+                                    hasRest = updateScheduleList.any { it.category == ScheduleCategory.LEAVE },
+                                ),
+                            )
+                        }
+                    },
+                )
+            }
+        }
+    }
 
     sealed interface CalendarDataProviderEvent {
         data object CompleteInitWeeksCalendar : CalendarDataProviderEvent

--- a/core/domain/src/main/java/team/noweekend/core/domain/usecase/ChangeCompleteScheduleUseCase.kt
+++ b/core/domain/src/main/java/team/noweekend/core/domain/usecase/ChangeCompleteScheduleUseCase.kt
@@ -1,0 +1,12 @@
+package team.noweekend.core.domain.usecase
+
+import team.noweekend.core.domain.repository.ScheduleRepository
+import team.noweekend.core.model.schedule.Schedule
+import javax.inject.Inject
+
+class ChangeCompleteScheduleUseCase @Inject constructor(
+    private val scheduleRepository: ScheduleRepository,
+) {
+    suspend operator fun invoke(id: String, isComplete: Boolean): Schedule =
+        scheduleRepository.changeCompleteSchedule(id = id, isComplete = isComplete)
+}

--- a/core/navigator/src/main/java/team/noweekend/core/navigator/model/DestinationRoute.kt
+++ b/core/navigator/src/main/java/team/noweekend/core/navigator/model/DestinationRoute.kt
@@ -18,7 +18,7 @@ data object Calendar : DestinationRoute
 @Serializable
 data class DetailDate(
     val date: String,
-    val todoList : String,
+    val todoList: String,
 ) : DestinationRoute
 
 @Serializable

--- a/core/navigator/src/main/java/team/noweekend/core/navigator/model/DestinationRoute.kt
+++ b/core/navigator/src/main/java/team/noweekend/core/navigator/model/DestinationRoute.kt
@@ -1,6 +1,7 @@
 package team.noweekend.core.navigator.model
 
 import kotlinx.serialization.Serializable
+import javax.annotation.concurrent.Immutable
 
 /**
  * 각 feature의 NavHost에서 전환 가능한 Composable의 Destination
@@ -13,8 +14,12 @@ data object Home : DestinationRoute
 @Serializable
 data object Calendar : DestinationRoute
 
+@Immutable
 @Serializable
-data object DetailDate : DestinationRoute
+data class DetailDate(
+    val date: String,
+    val todoList : String,
+) : DestinationRoute
 
 @Serializable
 data object Profile : DestinationRoute

--- a/core/remote/src/main/kotlin/team/noweekend/core/remote/api/schedule/ScheduleApi.kt
+++ b/core/remote/src/main/kotlin/team/noweekend/core/remote/api/schedule/ScheduleApi.kt
@@ -24,6 +24,11 @@ interface ScheduleApi {
         createScheduleRequest: ScheduleModel
     ): ScheduleModel
 
+    suspend fun changeCompleteSchedule(
+        id :String,
+        isComplete: Boolean
+    ) : ScheduleModel
+
     companion object {
         const val SCHEDULE_PATH: String = "/api/v1/schedule"
         const val START_DATE: String = "start_date"

--- a/core/remote/src/main/kotlin/team/noweekend/core/remote/api/schedule/ScheduleApiImpl.kt
+++ b/core/remote/src/main/kotlin/team/noweekend/core/remote/api/schedule/ScheduleApiImpl.kt
@@ -49,4 +49,12 @@ class ScheduleApiImpl @Inject constructor(
             body = createScheduleRequest,
         )
     }
+
+    override suspend fun changeCompleteSchedule(id: String, isComplete: Boolean): ScheduleModel {
+        return client.putApiCall(
+            path = ScheduleApi.SCHEDULE_PATH + "/${id}/state",
+            body = null,
+            queries = mapOf("is_complete" to isComplete)
+        )
+    }
 }

--- a/core/remote/src/main/kotlin/team/noweekend/core/remote/base/BaseApiCall.kt
+++ b/core/remote/src/main/kotlin/team/noweekend/core/remote/base/BaseApiCall.kt
@@ -27,7 +27,7 @@ internal suspend inline fun <reified T> HttpClient.getApiCall(
 internal suspend inline fun <reified T> HttpClient.postApiCall(
     path: String,
     body: Any? = null,
-    queries: Map<String, String>? = null,
+    queries: Map<String, Any>? = null,
 ): T =
     callApi<T> {
         this.post(path) {
@@ -41,7 +41,7 @@ internal suspend inline fun <reified T> HttpClient.postApiCall(
 internal suspend inline fun <reified T> HttpClient.putApiCall(
     path: String,
     body: Any? = null,
-    queries: Map<String, String>? = null,
+    queries: Map<String, Any>? = null,
 ): T =
     callApi<T> {
         this
@@ -56,7 +56,7 @@ internal suspend inline fun <reified T> HttpClient.putApiCall(
 
 internal suspend inline fun <reified T> HttpClient.deleteApiCall(
     path: String,
-    queries: Map<String, String>? = null,
+    queries: Map<String, Any>? = null,
 ): T =
     callApi<T> {
         this.delete(path) {

--- a/feature/calendar/src/main/kotlin/team/noweekend/feature/calendar/component/bottomsheet/TodoBottomSheet.kt
+++ b/feature/calendar/src/main/kotlin/team/noweekend/feature/calendar/component/bottomsheet/TodoBottomSheet.kt
@@ -68,6 +68,7 @@ private fun PreviewTodoBottomSheet() {
                 description = "",
                 todoType = TodoType.Etc(),
                 isDone = false,
+                id = "0"
             ),
             onDismissRequest = {},
             onClickAction = {},

--- a/feature/calendar/src/main/kotlin/team/noweekend/feature/calendar/model/mapper/TodoMapper.kt
+++ b/feature/calendar/src/main/kotlin/team/noweekend/feature/calendar/model/mapper/TodoMapper.kt
@@ -17,6 +17,7 @@ fun Schedule.toTodo(): Todo {
         description = getDescription(allDay = this.allDay, startTime = this.startTime),
         todoType = this.category.toTodoType(),
         isDone = this.completed,
+        id = this.id
     )
 }
 

--- a/feature/calendar/src/main/kotlin/team/noweekend/feature/calendar/mvi/CalendarIntent.kt
+++ b/feature/calendar/src/main/kotlin/team/noweekend/feature/calendar/mvi/CalendarIntent.kt
@@ -30,5 +30,9 @@ sealed interface CalendarIntent : Intent {
     data class UpdateCalendarDataAndChooser(val page: Int, val calendarMode: CalendarMode) : CalendarIntent
 
     data class UpdateTodoList(val targetDate : LocalDate): CalendarIntent
+    data class ChangeComplete(val index: Int): CalendarIntent
+
+    data object UpdateCalendarState : CalendarIntent
+
 
 }

--- a/feature/calendar/src/main/kotlin/team/noweekend/feature/calendar/mvi/CalendarSideEffect.kt
+++ b/feature/calendar/src/main/kotlin/team/noweekend/feature/calendar/mvi/CalendarSideEffect.kt
@@ -1,6 +1,5 @@
 package team.noweekend.feature.calendar.mvi
 
-import kotlinx.datetime.LocalDate
 import team.noweekend.core.common.android.mvi.SideEffect
 
 sealed interface CalendarSideEffect : SideEffect {

--- a/feature/calendar/src/main/kotlin/team/noweekend/feature/calendar/mvi/CalendarSideEffectHandler.kt
+++ b/feature/calendar/src/main/kotlin/team/noweekend/feature/calendar/mvi/CalendarSideEffectHandler.kt
@@ -53,7 +53,7 @@ class CalendarSideEffectHandler(
     private val updateNextWeekPage: (page: Int) -> Unit,
     private val updatePreviousMonthPage: (page: Int) -> Unit,
     private val updateNextMonthPage: (page: Int) -> Unit,
-    private val navigateToDetailDate : (String) -> Unit,
+    private val navigateToDetailDate : (date : String) -> Unit,
     private val calendarPagerState: CalendarPagerState,
     private val coroutineScope: CoroutineScope,
 ) : SideEffectHandler<CalendarSideEffect> {

--- a/feature/calendar/src/main/kotlin/team/noweekend/feature/calendar/mvi/CalendarViewModel.kt
+++ b/feature/calendar/src/main/kotlin/team/noweekend/feature/calendar/mvi/CalendarViewModel.kt
@@ -15,6 +15,7 @@ import team.noweekend.core.common.ui.calendar.model.CalendarDateOfWeek
 import team.noweekend.core.common.ui.calendar.model.CalendarMode
 import team.noweekend.core.common.ui.calendar.model.CalendarState
 import team.noweekend.core.domain.usecase.CalendarDataProviderUseCase
+import team.noweekend.core.domain.usecase.ChangeCompleteScheduleUseCase
 import team.noweekend.core.model.schedule.Schedule
 import team.noweekend.feature.calendar.model.CalendarDateOfWeekWithTodoList
 import team.noweekend.feature.calendar.model.CalendarWeeksDataWithTodoList
@@ -26,6 +27,7 @@ import javax.inject.Inject
 @HiltViewModel
 class CalendarViewModel @Inject constructor(
     private val calendarDataProviderUseCase: CalendarDataProviderUseCase,
+    private val changeCompleteScheduleUseCase: ChangeCompleteScheduleUseCase,
     savedStateHandle: SavedStateHandle,
 ) : MVIViewModel<CalendarIntent, CalendarSideEffect, CalendarUiState>(savedStateHandle = savedStateHandle) {
 
@@ -60,6 +62,8 @@ class CalendarViewModel @Inject constructor(
             is CalendarIntent.UpdateCalendarMode -> updateCalendarMode()
             is CalendarIntent.UpdateCalendarModeWithToggleState -> updateCalendarMode(isMonth = intent.isMonth)
             is CalendarIntent.InitCalendar -> initCalendar(initPage = intent.initPage)
+            is CalendarIntent.ChangeComplete -> changeCompleteSchedule(index = intent.index)
+            is CalendarIntent.UpdateCalendarState -> updateCalendarState()
         }
     }
 
@@ -196,7 +200,7 @@ class CalendarViewModel @Inject constructor(
         }
     }
 
-    private fun updateCalendarData() = execute {
+    private suspend fun updateCalendarData() {
         val weekDataFlow = calendarDataProviderUseCase.weeksDate
         val monthDataFlow = calendarDataProviderUseCase.monthData
         weekDataFlow.combine(monthDataFlow) { weekData, monthData ->
@@ -266,7 +270,7 @@ class CalendarViewModel @Inject constructor(
         }
     }
 
-    private fun updateCalendarState(
+    fun updateCalendarState(
         calendarMode: CalendarMode = currentState.calendarMode,
         initFirstTodoList: Boolean = false,
     ) {
@@ -295,25 +299,33 @@ class CalendarViewModel @Inject constructor(
             this.copy(
                 selectedTodoList = selectedTodoList,
                 calendarState = when (calendarMode) {
-                    CalendarMode.WEEK -> CalendarState.Week(
-                        mode = calendarMode,
-                        selectedDate = calendarDataProviderUseCase.targetDate.value,
-                        pagerState = this.calendarPagerState.weekPagerState,
-                        pagerData = this.calendarWeeksData.toList()
-                            .associate { (key, value) ->
-                                key to value.toCalendarWeeksData()
-                            }.toImmutableMap(),
-                    )
+                    CalendarMode.WEEK -> {
+                        val pagerData = this.calendarWeeksData.toList().associate { (key, value) ->
+                            key to value.toCalendarWeeksData()
+                        }.toImmutableMap()
 
-                    CalendarMode.MONTH -> CalendarState.Month(
-                        mode = calendarMode,
-                        selectedDate = this.calendarState.selectedDate,
-                        pagerState = this.calendarPagerState.monthPagerState,
-                        pagerData = this.calendarMonthsData.toList()
+                        CalendarState.Week(
+                            mode = calendarMode,
+                            selectedDate = calendarDataProviderUseCase.targetDate.value,
+                            pagerState = this.calendarPagerState.weekPagerState,
+                            pagerData = pagerData,
+                        )
+                    }
+
+
+                    CalendarMode.MONTH -> {
+                        val pagerData = this.calendarMonthsData.toList()
                             .associate { (key, value) ->
                                 key to value.toCalendarWeeksData()
-                            }.toImmutableMap(),
-                    )
+                            }.toImmutableMap()
+
+                        CalendarState.Month(
+                            mode = calendarMode,
+                            selectedDate = this.calendarState.selectedDate,
+                            pagerState = this.calendarPagerState.monthPagerState,
+                            pagerData = pagerData,
+                        )
+                    }
                 },
             )
         }
@@ -356,4 +368,22 @@ class CalendarViewModel @Inject constructor(
         }
     }
 
+
+    private suspend fun changeCompleteSchedule(index: Int) {
+        val todo = currentState.selectedTodoList[index]
+
+        val schedule: Schedule = changeCompleteScheduleUseCase(id = todo.id, isComplete = todo.isDone.not())
+
+        calendarDataProviderUseCase.updateWeeksDataWithSchedule(schedule = schedule)
+
+
+        reduce {
+            this.copy(
+                selectedTodoList = currentState.selectedTodoList.mapIndexed { innerIndex, todo ->
+                    if (innerIndex == index) todo.copy(isDone = schedule.completed) else todo
+                }.toImmutableList(),
+            )
+        }
+
+    }
 }

--- a/feature/calendar/src/main/kotlin/team/noweekend/feature/calendar/mvi/builder/IntentBuilder.kt
+++ b/feature/calendar/src/main/kotlin/team/noweekend/feature/calendar/mvi/builder/IntentBuilder.kt
@@ -90,4 +90,12 @@ class IntentBuilder(
         build(CalendarIntent.UpdateTodoList(targetDate = targetDate))
     }
 
+    fun changeCompleteSchedule(index: Int) {
+        build(CalendarIntent.ChangeComplete(index = index))
+    }
+
+    fun updateCalendarState(){
+        build(CalendarIntent.UpdateCalendarState)
+    }
+
 }

--- a/feature/calendar/src/main/kotlin/team/noweekend/feature/calendar/screen/CalendarRoute.kt
+++ b/feature/calendar/src/main/kotlin/team/noweekend/feature/calendar/screen/CalendarRoute.kt
@@ -16,6 +16,10 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
+import androidx.lifecycle.compose.LifecycleResumeEffect
+import androidx.lifecycle.compose.LifecycleStartEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.datetime.LocalDate
 import team.noweekend.core.common.android.extension.fillMaxWidthOfScreen
@@ -56,12 +60,15 @@ internal fun CalendarRoute(
 
 
 
-    LaunchedEffect(Unit) {
+    LaunchedEffect(Unit){
         with(intentBuilder) {
             collectCalendarEvent()
             updateCalendarData()
+            calendarViewModel.sideEffect.collect(calendarSideEffectHandler::handleSideEffect)
         }
-        calendarViewModel.sideEffect.collect(calendarSideEffectHandler::handleSideEffect)
+    }
+    LifecycleEventEffect(Lifecycle.Event.ON_START) {
+        intentBuilder.updateCalendarState()
     }
     LaunchedEffect(state.value.calendarMode) {
         with(intentBuilder) {
@@ -103,7 +110,7 @@ internal fun CalendarRoute(
             onClickToggle = intentBuilder::updateCalendarMode,
             onClickDateOfWeek = intentBuilder::updateTargetDate,
             onClickYearMonthButton = {},
-            onClickCheckBox = {},
+            onClickCheckBox = intentBuilder::changeCompleteSchedule,
             onClickOptionButton = {},
             todoList = state.value.selectedTodoList,
         )

--- a/feature/detail-date/src/main/java/team/noweekend/feature/detail/date/DetailDateActivity.kt
+++ b/feature/detail-date/src/main/java/team/noweekend/feature/detail/date/DetailDateActivity.kt
@@ -7,6 +7,8 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.ui.Modifier
 import dagger.hilt.android.AndroidEntryPoint
+import team.noweekend.core.design.system.foundation.theme.NWKTheme
+import team.noweekend.core.navigator.model.DetailDate
 import team.noweekend.feature.detail.date.navigation.DetailDateNavHost
 
 @AndroidEntryPoint
@@ -17,10 +19,15 @@ class DetailDateActivity : ComponentActivity() {
         enableEdgeToEdge()
 
         setContent {
-            DetailDateNavHost(
-                modifier = Modifier.fillMaxSize(),
-                onClickBackButton = ::finish,
-            )
+            NWKTheme {
+                val date = intent.getStringExtra("date") ?: ""
+                val todoList: String = intent.getStringExtra("todoList") ?: ""
+                DetailDateNavHost(
+                    startDestination = DetailDate(date = date, todoList = todoList),
+                    modifier = Modifier.fillMaxSize(),
+                    onClickBackButton = ::finish,
+                )
+            }
         }
     }
 }

--- a/feature/detail-date/src/main/java/team/noweekend/feature/detail/date/model/mapper/TodoMapper.kt
+++ b/feature/detail-date/src/main/java/team/noweekend/feature/detail/date/model/mapper/TodoMapper.kt
@@ -17,7 +17,7 @@ fun Schedule.toTodo(): Todo {
         description = getDescription(allDay = this.allDay, startTime = this.startTime),
         todoType = this.category.toTodoType(),
         isDone = this.completed,
-        id = this.id
+        id = this.id,
     )
 }
 
@@ -40,4 +40,3 @@ fun getDescription(allDay: Boolean, startTime: String): String {
         localDateTime.toFormattedString(pattern = LocalTime.MERIDIEM_HOUR_MINUTE_KR_PATTERN)
     }
 }
-

--- a/feature/detail-date/src/main/java/team/noweekend/feature/detail/date/model/mapper/TodoMapper.kt
+++ b/feature/detail-date/src/main/java/team/noweekend/feature/detail/date/model/mapper/TodoMapper.kt
@@ -1,0 +1,43 @@
+package team.noweekend.feature.detail.date.model.mapper
+
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
+import team.noweekend.core.common.kotlin.extension.MERIDIEM_HOUR_MINUTE_KR_PATTERN
+import team.noweekend.core.common.kotlin.extension.MONTH_DATE_WITH_DAY_OF_WEEK_KR_PATTERN
+import team.noweekend.core.common.kotlin.extension.toFormattedString
+import team.noweekend.core.common.ui.todo.model.Todo
+import team.noweekend.core.common.ui.todo.model.TodoType
+import team.noweekend.core.model.schedule.Schedule
+import team.noweekend.core.model.schedule.ScheduleCategory
+
+fun Schedule.toTodo(): Todo {
+    return Todo(
+        title = this.title,
+        description = getDescription(allDay = this.allDay, startTime = this.startTime),
+        todoType = this.category.toTodoType(),
+        isDone = this.completed,
+        id = this.id
+    )
+}
+
+fun ScheduleCategory.toTodoType(): TodoType {
+    return when (this) {
+        ScheduleCategory.ETC -> TodoType.Etc()
+        ScheduleCategory.LEAVE -> TodoType.AnnualLeave()
+        ScheduleCategory.COMPANY -> TodoType.Company()
+        ScheduleCategory.PERSONAL -> TodoType.Personal()
+    }
+}
+
+fun getDescription(allDay: Boolean, startTime: String): String {
+    val localDateTime = LocalDateTime.parse(startTime)
+    return if (allDay) {
+        localDateTime.toFormattedString(
+            pattern = LocalDate.MONTH_DATE_WITH_DAY_OF_WEEK_KR_PATTERN,
+        )
+    } else {
+        localDateTime.toFormattedString(pattern = LocalTime.MERIDIEM_HOUR_MINUTE_KR_PATTERN)
+    }
+}
+

--- a/feature/detail-date/src/main/java/team/noweekend/feature/detail/date/mvi/DetailDateIntent.kt
+++ b/feature/detail-date/src/main/java/team/noweekend/feature/detail/date/mvi/DetailDateIntent.kt
@@ -2,4 +2,8 @@ package team.noweekend.feature.detail.date.mvi
 
 import team.noweekend.core.common.android.mvi.Intent
 
-sealed interface DetailDateIntent : Intent
+sealed interface DetailDateIntent : Intent{
+    data object InitState: DetailDateIntent
+
+    data class ChangeComplete(val index: Int): DetailDateIntent
+}

--- a/feature/detail-date/src/main/java/team/noweekend/feature/detail/date/mvi/DetailDateIntent.kt
+++ b/feature/detail-date/src/main/java/team/noweekend/feature/detail/date/mvi/DetailDateIntent.kt
@@ -2,8 +2,8 @@ package team.noweekend.feature.detail.date.mvi
 
 import team.noweekend.core.common.android.mvi.Intent
 
-sealed interface DetailDateIntent : Intent{
-    data object InitState: DetailDateIntent
+sealed interface DetailDateIntent : Intent {
+    data object InitState : DetailDateIntent
 
-    data class ChangeComplete(val index: Int): DetailDateIntent
+    data class ChangeComplete(val index: Int) : DetailDateIntent
 }

--- a/feature/detail-date/src/main/java/team/noweekend/feature/detail/date/mvi/DetailDateUiState.kt
+++ b/feature/detail-date/src/main/java/team/noweekend/feature/detail/date/mvi/DetailDateUiState.kt
@@ -2,6 +2,7 @@ package team.noweekend.feature.detail.date.mvi
 
 import androidx.compose.runtime.Immutable
 import kotlinx.collections.immutable.ImmutableList
+import kotlinx.datetime.LocalDate
 import team.noweekend.core.common.android.mvi.UiState
 import team.noweekend.core.common.ui.todo.model.Todo
 import team.noweekend.feature.detail.date.model.DegreeUIModel
@@ -9,6 +10,7 @@ import team.noweekend.feature.detail.date.model.DegreeUIModel
 @Immutable
 data class DetailDateUiState(
     val dateTitle: String,
+    val date: LocalDate,
     val todoList: ImmutableList<Todo>,
     val degreeUiModel: DegreeUIModel,
 ) : UiState

--- a/feature/detail-date/src/main/java/team/noweekend/feature/detail/date/mvi/DetailDateViewModel.kt
+++ b/feature/detail-date/src/main/java/team/noweekend/feature/detail/date/mvi/DetailDateViewModel.kt
@@ -1,24 +1,37 @@
 package team.noweekend.feature.detail.date.mvi
 
 import androidx.lifecycle.SavedStateHandle
+import androidx.navigation.toRoute
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
+import kotlinx.datetime.LocalDate
 import team.noweekend.core.common.android.base.MVIViewModel
+import team.noweekend.core.common.kotlin.extension.parseLocalDateString
 import team.noweekend.core.domain.usecase.CalendarDataProviderUseCase
+import team.noweekend.core.domain.usecase.ChangeCompleteScheduleUseCase
+import team.noweekend.core.model.schedule.Schedule
+import team.noweekend.core.model.schedule.ScheduleCategory
+import team.noweekend.core.navigator.model.DetailDate
 import team.noweekend.feature.detail.date.model.DegreeUIModel
+import team.noweekend.feature.detail.date.model.mapper.toTodo
 import javax.inject.Inject
 
 @HiltViewModel
 class DetailDateViewModel @Inject constructor(
     private val calendarDateProviderUseCase: CalendarDataProviderUseCase,
+    private val changeCompleteScheduleUseCase: ChangeCompleteScheduleUseCase,
     savedStateHandle: SavedStateHandle,
 ) : MVIViewModel<DetailDateIntent, DetailDateSideEffect, DetailDateUiState>(
     savedStateHandle = savedStateHandle,
 ) {
-
     override fun createInitialState(savedStateHandle: SavedStateHandle): DetailDateUiState {
+
+        val date = savedStateHandle.toRoute<DetailDate>().date
+        val localDate = LocalDate.parseLocalDateString(date)
         return DetailDateUiState(
-            dateTitle = savedStateHandle.get<String>("date") ?: "",
+            dateTitle = date,
+            date = localDate,
             degreeUiModel = DegreeUIModel(degree = 0, isAnnualLeave = false),
             todoList = persistentListOf(),
         )
@@ -32,5 +45,60 @@ class DetailDateViewModel @Inject constructor(
     }
 
     override suspend fun handleIntent(intent: DetailDateIntent) {
+        when (intent) {
+            is DetailDateIntent.InitState -> initState()
+            is DetailDateIntent.ChangeComplete -> changeCompleteSchedule(
+                index = intent.index,
+            )
+        }
+    }
+
+    private suspend fun initState() {
+        calendarDateProviderUseCase.monthData.collect { weeksDateMap ->
+            val scheduleList = weeksDateMap.values.toList().map { weeksData ->
+                weeksData.dateOfWeeks.flatten().filter { dateOfWeek ->
+                    dateOfWeek.localDate == uiState.value.date
+                }.map { dateOfWeek ->
+                    dateOfWeek.scheduleList
+                }.flatten()
+            }.flatten().map { schedule ->
+                schedule
+            }.toImmutableList()
+
+            val todoList = scheduleList.map { schedule ->
+                schedule.toTodo()
+            }.toImmutableList()
+
+            reduce {
+                this.copy(
+                    todoList = todoList,
+                    degreeUiModel = DegreeUIModel(
+                        degree = scheduleList.filter { schedule -> schedule.completed }
+                            .sumOf { schedule -> schedule.temperature },
+                        isAnnualLeave = scheduleList.any { schedule -> schedule.category == ScheduleCategory.LEAVE }
+                    )
+                )
+            }
+        }
+    }
+
+    private suspend fun changeCompleteSchedule(index: Int) {
+        val todo = currentState.todoList[index]
+
+        val schedule: Schedule =
+            changeCompleteScheduleUseCase(id = todo.id, isComplete = todo.isDone.not())
+
+        calendarDateProviderUseCase.updateMonthsDataWithSchedule(schedule = schedule)
+
+        reduce {
+            this.copy(
+                todoList = currentState.todoList.mapIndexed { innerIndex, todo ->
+                    if (innerIndex == index) todo.copy(
+                        isDone = schedule.completed
+                    ) else todo
+                }.toImmutableList()
+            )
+        }
+
     }
 }

--- a/feature/detail-date/src/main/java/team/noweekend/feature/detail/date/mvi/DetailDateViewModel.kt
+++ b/feature/detail-date/src/main/java/team/noweekend/feature/detail/date/mvi/DetailDateViewModel.kt
@@ -26,7 +26,6 @@ class DetailDateViewModel @Inject constructor(
     savedStateHandle = savedStateHandle,
 ) {
     override fun createInitialState(savedStateHandle: SavedStateHandle): DetailDateUiState {
-
         val date = savedStateHandle.toRoute<DetailDate>().date
         val localDate = LocalDate.parseLocalDateString(date)
         return DetailDateUiState(
@@ -75,8 +74,8 @@ class DetailDateViewModel @Inject constructor(
                     degreeUiModel = DegreeUIModel(
                         degree = scheduleList.filter { schedule -> schedule.completed }
                             .sumOf { schedule -> schedule.temperature },
-                        isAnnualLeave = scheduleList.any { schedule -> schedule.category == ScheduleCategory.LEAVE }
-                    )
+                        isAnnualLeave = scheduleList.any { schedule -> schedule.category == ScheduleCategory.LEAVE },
+                    ),
                 )
             }
         }
@@ -93,12 +92,15 @@ class DetailDateViewModel @Inject constructor(
         reduce {
             this.copy(
                 todoList = currentState.todoList.mapIndexed { innerIndex, todo ->
-                    if (innerIndex == index) todo.copy(
-                        isDone = schedule.completed
-                    ) else todo
-                }.toImmutableList()
+                    if (innerIndex == index) {
+                        todo.copy(
+                            isDone = schedule.completed,
+                        )
+                    } else {
+                        todo
+                    }
+                }.toImmutableList(),
             )
         }
-
     }
 }

--- a/feature/detail-date/src/main/java/team/noweekend/feature/detail/date/mvi/builder/IntentBuilder.kt
+++ b/feature/detail-date/src/main/java/team/noweekend/feature/detail/date/mvi/builder/IntentBuilder.kt
@@ -1,0 +1,28 @@
+package team.noweekend.feature.detail.date.mvi.builder
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.remember
+import team.noweekend.feature.detail.date.mvi.DetailDateIntent
+
+@Composable
+fun rememberIntentBuilder(
+    send: (DetailDateIntent) -> Unit,
+) = remember {
+    IntentBuilder(send = send)
+}
+
+@Stable
+class IntentBuilder(
+    private val send: (DetailDateIntent) -> Unit,
+) {
+
+    private fun build(detailDateIntent: DetailDateIntent) {
+        send(detailDateIntent)
+    }
+
+    fun changeCompleteSchedule(index: Int) {
+        build(DetailDateIntent.ChangeComplete(index = index))
+    }
+
+}

--- a/feature/detail-date/src/main/java/team/noweekend/feature/detail/date/mvi/builder/IntentBuilder.kt
+++ b/feature/detail-date/src/main/java/team/noweekend/feature/detail/date/mvi/builder/IntentBuilder.kt
@@ -24,5 +24,4 @@ class IntentBuilder(
     fun changeCompleteSchedule(index: Int) {
         build(DetailDateIntent.ChangeComplete(index = index))
     }
-
 }

--- a/feature/detail-date/src/main/java/team/noweekend/feature/detail/date/navigation/DetailDateNavHost.kt
+++ b/feature/detail-date/src/main/java/team/noweekend/feature/detail/date/navigation/DetailDateNavHost.kt
@@ -13,6 +13,7 @@ import team.noweekend.feature.detail.date.screen.DetailDateRoute
 
 @Composable
 fun DetailDateNavHost(
+    startDestination: DetailDate,
     onClickBackButton: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -25,7 +26,7 @@ fun DetailDateNavHost(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(it),
-            startDestination = DetailDate,
+            startDestination = startDestination,
         ) {
             composable<DetailDate> {
                 DetailDateRoute(

--- a/feature/detail-date/src/main/java/team/noweekend/feature/detail/date/screen/DetailDateRoute.kt
+++ b/feature/detail-date/src/main/java/team/noweekend/feature/detail/date/screen/DetailDateRoute.kt
@@ -1,10 +1,14 @@
 package team.noweekend.feature.detail.date.screen
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.LifecycleResumeEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import team.noweekend.feature.detail.date.mvi.DetailDateIntent
 import team.noweekend.feature.detail.date.mvi.DetailDateViewModel
+import team.noweekend.feature.detail.date.mvi.builder.rememberIntentBuilder
 
 @Composable
 internal fun DetailDateRoute(
@@ -14,10 +18,18 @@ internal fun DetailDateRoute(
 ) {
     val state = detailDateViewModel.uiState.collectAsStateWithLifecycle()
 
+    val intentBuilder= rememberIntentBuilder(
+        send = detailDateViewModel::intent
+    )
+
+    LaunchedEffect(Unit) {
+        detailDateViewModel.intent(DetailDateIntent.InitState)
+    }
+
     DetailDateScreen(
         modifier = modifier,
         detailDateUiState = state.value,
-        onClickCheckBox = {},
+        onClickCheckBox = intentBuilder::changeCompleteSchedule,
         onClickOptionButton = {},
         onClickBackButton = onClickBackButton,
     )

--- a/feature/detail-date/src/main/java/team/noweekend/feature/detail/date/screen/DetailDateRoute.kt
+++ b/feature/detail-date/src/main/java/team/noweekend/feature/detail/date/screen/DetailDateRoute.kt
@@ -4,7 +4,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.compose.LifecycleResumeEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import team.noweekend.feature.detail.date.mvi.DetailDateIntent
 import team.noweekend.feature.detail.date.mvi.DetailDateViewModel
@@ -18,8 +17,8 @@ internal fun DetailDateRoute(
 ) {
     val state = detailDateViewModel.uiState.collectAsStateWithLifecycle()
 
-    val intentBuilder= rememberIntentBuilder(
-        send = detailDateViewModel::intent
+    val intentBuilder = rememberIntentBuilder(
+        send = detailDateViewModel::intent,
     )
 
     LaunchedEffect(Unit) {

--- a/feature/detail-date/src/main/java/team/noweekend/feature/detail/date/screen/DetailDateScreen.kt
+++ b/feature/detail-date/src/main/java/team/noweekend/feature/detail/date/screen/DetailDateScreen.kt
@@ -6,6 +6,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.datetime.LocalDate
+import team.noweekend.core.common.kotlin.extension.now
 import team.noweekend.core.common.ui.calendar.component.CalendarTodoList
 import team.noweekend.core.design.system.foundation.theme.NWKTheme
 import team.noweekend.feature.detail.date.component.DegreeCard
@@ -57,6 +59,7 @@ private fun PreviewDateDetailScreen() {
                     degree = 50,
                     isAnnualLeave = true,
                 ),
+                date = LocalDate.now(),
                 todoList = persistentListOf(),
             ),
             onClickBackButton = {},


### PR DESCRIPTION
### What is this PR (Required)
- **Issue Number** : close #131 
- **Figma :**
- 기타 관련 문서 :

### Changes (Required)
- 월별 캘린더에서 할일 완료 클릭 후 이전 뷰 돌아올시, 데이터가 반영되도록 함.

### Review Point (Required)
- CalendarDataProvider를 singleton으로 만들어서 공유하도록 했는데 사이드 이팩트가 예상되어 별도 대응할께
- 아마 캘린더에서 데이터를 수정하면 홈에서도 반영될꺼같아서, 해당 건 찾아서 수정하고 캘린더 로직 연결할께 

### Screenshot
| 기능 | 스크린샷 |
| --- | --- |
| gif | <img src="https://github.com/user-attachments/assets/671a7012-e18c-4ac8-9dc7-d6b69c041fb4" width="300" /> |

### 관련 Reference 자료
-